### PR TITLE
Create DRP, remove verifier keys from new

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,55 @@ The program is obtained from the [new program output](#new-program)
 Example:
 
 ```bash
-bitvmx » program -i 6a3367ec-5341-447e-abd7-29e9d8dc5b67
+bitvmx » program -i 7899be78-dcfb-4b2b-9f34-2bb48aa75048
 ```
 
+Output will be like
+
+```
++--------------------------------------+--------------------------------------------------------------------+
+| Program (Inactive)                   | Funding tx                                                         |
+| 7899be78-dcfb-4b2b-9f34-2bb48aa75048 | 0db4359e24b446acc0bdeb78a210ecb07eeb708fdfdb4c088a6655c1d8abc4cf:1 |
+|--------------------------------------+--------------------------------------------------------------------|
+| Amounts                              | Funding 100000000                                                  |
+|                                      | Protocol 2450000                                                   |
+|                                      | Timelock 95000000                                                  |
+|                                      | Speedup 2450000                                                    |
+|--------------------------------------+--------------------------------------------------------------------|
+| Prover p2p information               | Address /ip4/127.0.0.1/tcp/61180                                   |
+|                                      | Peer Id 12D3KooWSYPZx6XNGMTqmjVftriFopc5orpEDmVAZQUcVzSUPcux       |
+|--------------------------------------+--------------------------------------------------------------------|
+| Verifier p2p information             | Address /ip4/127.0.0.1/tcp/61181                                   |
+|                                      | Peer Id 12D3KooWCL2CbGe2uHPo5CSPy7SuWSji9RjP18hRwVdvdMFK8uuC       |
+|--------------------------------------+--------------------------------------------------------------------|
+| Common ECDSA keys                    | Internal (Taproot)                                                 |
+|                                      | aa701c613ac50d5aab1f0bdce1e4cef931bd758eb0f5c6e29966497e36f76e25   |
+|                                      |                                                                    |
+|                                      | Protocol                                                           |
+|                                      | 02a4885ddf0910e0208bee0363db51b514f800fe893b9bb4c52aac56a7d71af047 |
+|--------------------------------------+--------------------------------------------------------------------|
+| Prover ECDSA keys                    | Pre-kickoff                                                        |
+|                                      | 021e250b649c3396589a337c2c8a384ca7477264950cd7bd277fe1c5941f3178ee |
+|                                      |                                                                    |
+|                                      | Timelock                                                           |
+|                                      | 0356272fc7b091676973e32a49bea98f49951e389331c04bd866676c0ec78bdb88 |
+|                                      |                                                                    |
+|                                      | Speedup                                                            |
+|                                      | 0235ef3b11b06e91fadd15d9f01ab04d2e751b6f3043273bdff145cdab3a171aba |
+|--------------------------------------+--------------------------------------------------------------------|
+| Prover dispute resolution keys       | Count 10                                                           |
+|                                      | Type HASH160                                                       |
+|--------------------------------------+--------------------------------------------------------------------|
+| Verifier ECDSA keys                  | Timelock                                                           |
+|                                      | None                                                               |
+|                                      |                                                                    |
+|                                      | Speedup                                                            |
+|                                      | None                                                               |
+|--------------------------------------+--------------------------------------------------------------------|
+| Verifier dispute resolution keys     | Count 0                                                            |
+|                                      | Type None                                                          |
++--------------------------------------+--------------------------------------------------------------------+
+```
   
 ## User journey
 

--- a/src/program/dispute.rs
+++ b/src/program/dispute.rs
@@ -81,7 +81,6 @@ impl DisputeResolutionProtocol {
         protocol_storage: PathBuf,
         funding: Funding,
         prover: &ParticipantKeys,
-        verifier: &ParticipantKeys,
         search: SearchParams,
     ) -> Result<DisputeResolutionProtocol, ProtocolBuilderError> {
         let ecdsa_sighash_type = SighashType::ecdsa_all();

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{config::Config, errors::{BitVMXError, ProgramError}};
 
-use super::{dispute::{DisputeResolutionProtocol, Funding, SearchParams}, participant::{P2PAddress, Participant}};
+use super::{dispute::{DisputeResolutionProtocol, Funding, SearchParams}, participant::{P2PAddress, Participant, ParticipantKeys}};
 
 #[derive(PartialEq, Clone)]
 pub enum ProgramState {
@@ -69,22 +69,24 @@ impl Program {
         let protocol_name = "drp";
         let program_path = config.program_storage_path(id);
         let protocol_storage = program_path.join(protocol_name);
+        let search_params = SearchParams::new(8,32);
 
-        // let drp = DisputeResolutionProtocol::new(
-        //     &protocol_name,
-        //     protocol_storage,
-        //     funding,
-        //     &prover.keys(),
-        //     &verifier.keys(),
-        //     search_params
-        // )?;
+
+
+        let drp = Some(DisputeResolutionProtocol::new(
+            &protocol_name,
+            protocol_storage,
+            funding.clone(),
+            &prover.keys().unwrap(),
+            search_params
+        )?);
 
         Ok(Program {
             id,
             creator: creator.clone(),
             prover,
             verifier,
-            drp: None,
+            drp,
             funding,
             state: ProgramState::Inactive,
             trace: Trace {},


### PR DESCRIPTION
Verifier keys are not neccessary when creating a new program (setup) and a new DisputeResolutionProtocol. 
They will be added later on once the program is created before deployment

See expected flow
![image](https://github.com/user-attachments/assets/c2a6eacf-ded1-4258-8958-b9346fa04b15)
