### PR TITLE
Update dispatch method with block height target

### DIFF
--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -535,9 +535,11 @@ impl BitVMXApi for BitVMX {
     ) -> Result<(), BitVMXError> {
         info!("Dispatching transaction: {:?} for instance: {:?}", tx, id);
 
-        self.program_context
-            .bitcoin_coordinator
-            .dispatch(tx, Context::RequestId(id, from).to_string()?)?;
+        self.program_context.bitcoin_coordinator.dispatch(
+            tx,
+            Context::RequestId(id, from).to_string()?,
+            None,
+        )?;
         Ok(())
     }
 

--- a/src/program/dispute.rs
+++ b/src/program/dispute.rs
@@ -7,7 +7,13 @@ use bitcoin::{
 use bitcoin_coordinator::{coordinator::BitcoinCoordinatorApi, TransactionStatus};
 use key_manager::winternitz::WinternitzType;
 use protocol_builder::{
-    builder::Protocol, errors::ProtocolBuilderError, scripts, types::{input::{LeafSpec, SighashType}, InputArgs, OutputType, Utxo}
+    builder::Protocol,
+    errors::ProtocolBuilderError,
+    scripts,
+    types::{
+        input::{LeafSpec, SighashType},
+        InputArgs, OutputType, Utxo,
+    },
 };
 use serde::{Deserialize, Serialize};
 use storage_backend::storage::Storage;
@@ -92,9 +98,11 @@ impl ProtocolHandler for DisputeResolutionProtocol {
             let tx_to_dispatch = self.input_1_tx(0x1234_4444, &program_context.key_chain)?;
 
             let context = Context::ProgramId(self.ctx.id);
-            program_context
-                .bitcoin_coordinator
-                .dispatch(tx_to_dispatch, context.to_string()?)?;
+            program_context.bitcoin_coordinator.dispatch(
+                tx_to_dispatch,
+                context.to_string()?,
+                None,
+            )?;
         }
 
         if name == INPUT_1

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -844,7 +844,7 @@ impl Program {
 
         program_context
             .bitcoin_coordinator
-            .dispatch(tx_to_dispatch, context.to_string()?)?;
+            .dispatch(tx_to_dispatch, context.to_string()?, None)?;
         Ok(())
     }
 


### PR DESCRIPTION
# Changes 

Update the `dispatch()` method in the Coordinator to support None as a block height.
A block height in None indicates that the transaction should be dispatched at that moment.

Block height target was introduced in [Coordinator](https://github.com/FairgateLabs/rust-bitcoin-coordinator/pull/19)