### PR TITLE
DRP updates

### DIFF
--- a/src/program/protocols/dispute.rs
+++ b/src/program/protocols/dispute.rs
@@ -262,8 +262,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
             self.role()
         );
 
-        //TODO: use force
-        let (fail_config_prover, fail_config_verifier, _force, force_condition) = program_context
+        let (fail_config_prover, fail_config_verifier, force, force_condition) = program_context
             .globals
             .get_var(&self.ctx.id, "fail_force_config")?
             .unwrap()
@@ -387,7 +386,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
                     last_step,
                     hex::encode(last_hash),
                     format!("{}/{}", execution_path, "execution.json").to_string(),
-                    force_condition.clone(),
+                    force_condition,
                     fail_config_verifier.clone(),
                 ),
             })?;
@@ -640,6 +639,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
                     final_trace,
                     format!("{}/{}", execution_path, "execution.json").to_string(),
                     fail_config_verifier.clone(),
+                    force,
                 ),
             })?;
             program_context.broker_channel.send(EMULATOR_ID, msg)?;

--- a/src/program/variables.rs
+++ b/src/program/variables.rs
@@ -31,7 +31,7 @@ pub enum VariableTypes {
         Option<FailConfiguration>,
         Option<FailConfiguration>,
         emulator::decision::challenge::ForceChallenge,
-        Option<emulator::decision::challenge::ForceCondition>,
+        emulator::decision::challenge::ForceCondition,
     ),
 }
 
@@ -84,7 +84,7 @@ impl VariableTypes {
             Option<FailConfiguration>,
             Option<FailConfiguration>,
             emulator::decision::challenge::ForceChallenge,
-            Option<emulator::decision::challenge::ForceCondition>,
+            emulator::decision::challenge::ForceCondition,
         ),
         BitVMXError,
     > {

--- a/tests/fulltest.rs
+++ b/tests/fulltest.rs
@@ -7,6 +7,7 @@ use bitcoin::{
 use bitvmx_client::{
     program::{
         self,
+        participant::ParticipantRole,
         protocols::{
             dispute::TIMELOCK_BLOCKS, protocol_handler::external_fund_tx, slot::group_id,
             transfer::pub_too_group,
@@ -191,7 +192,7 @@ pub fn test_full() -> Result<()> {
         tx_fee as u32,
         fake_drp,
         fake_instruction,
-        ForcedChallenges::TraceHash,
+        ForcedChallenges::TraceHash(ParticipantRole::Prover),
     )?;
 
     //WAIT SETUP READY

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -10,7 +10,9 @@ use bitvmx_client::program::variables::VariableTypes;
 use bitvmx_client::types::{
     IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, BITVMX_ID, L2_ID,
 };
-use bitvmx_client::{bitvmx::BitVMX, config::Config, types::EMULATOR_ID};
+use bitvmx_client::{
+    bitvmx::BitVMX, config::Config, program::participant::ParticipantRole, types::EMULATOR_ID,
+};
 use bitvmx_job_dispatcher::DispatcherHandler;
 use bitvmx_job_dispatcher_types::emulator_messages::EmulatorJobType;
 use bitvmx_wallet::wallet::Wallet;
@@ -390,7 +392,7 @@ pub fn test_all_aux(independent: bool, network: Network) -> Result<()> {
         10_000,
         false,
         true,
-        ForcedChallenges::TraceHash,
+        ForcedChallenges::TraceHash(ParticipantRole::Prover),
     )?;
 
     let msg = helper.wait_msg(0)?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use bitvmx_client::types::{IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, BITVMX_ID};
+use bitvmx_client::{
+    program::participant::ParticipantRole,
+    types::{IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, BITVMX_ID},
+};
 use common::{
     config_trace,
     dispute::{execute_dispute, prepare_dispute, ForcedChallenges},
@@ -83,7 +86,7 @@ pub fn test_drp() -> Result<()> {
         10_000,
         false,
         false,
-        ForcedChallenges::TraceHash,
+        ForcedChallenges::ProgramCounter(ParticipantRole::Verifier),
     )?;
     let _msgs = get_all(&channels, &mut instances, false)?;
 

--- a/tests/slottest.rs
+++ b/tests/slottest.rs
@@ -3,6 +3,7 @@ use bitcoin::Amount;
 use bitvmx_client::{
     program::{
         self,
+        participant::ParticipantRole,
         protocols::{dispute::TIMELOCK_BLOCKS, protocol_handler::external_fund_tx, slot::group_id},
         variables::VariableTypes,
     },
@@ -167,7 +168,7 @@ pub fn test_slot() -> Result<()> {
         tx_fee as u32,
         fake_drp,
         fake_instruction,
-        ForcedChallenges::TraceHash,
+        ForcedChallenges::TraceHash(ParticipantRole::Prover),
     )?;
     let _msgs = get_all(&channels, &mut instances, false)?;
     info!("Dispute setup done");


### PR DESCRIPTION
Resolved various bugs during the challenge phase. Introduced support for the force parameter and the fail_config mechanism. It is now possible to generate different types of challenges by selecting them directly in the tests, with internal configuration managed by FailConfiguration. Additionally, the role of the malicious entity (Prover or Verifier) can now be selected for testing purposes.