### PR TITLE
Print version and git hash

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,53 +1,62 @@
+#[cfg(target_family = "unix")]
 use std::path::Path;
+#[cfg(target_family = "unix")]
 use std::process::Command;
 
 fn main() {
-    // --- Tell Cargo when to rerun (important!) ---
-    // Re-run if the branch HEAD moves.
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    // Re-run if the HEAD points to a branch ref and that ref moves.
-    if let Some(head_ref) = read_cmd(&["symbolic-ref", "-q", "HEAD"]) {
-        // e.g., "refs/heads/main"
-        let ref_path = format!(".git/{}", head_ref.trim());
-        println!("cargo:rerun-if-changed={}", ref_path);
+    #[cfg(target_family = "unix")]
+    {
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+
+        // --- Tell Cargo when to rerun (important!) ---
+        // Re-run if the branch HEAD moves.
+        println!("cargo:rerun-if-changed=.git/HEAD");
+        // Re-run if the HEAD points to a branch ref and that ref moves.
+        if let Some(head_ref) = read_cmd(&["symbolic-ref", "-q", "HEAD"]) {
+            // e.g., "refs/heads/main"
+            let ref_path = format!(".git/{}", head_ref.trim());
+            println!("cargo:rerun-if-changed={}", ref_path);
+        }
+        // Also handle packed refs (some repos store refs here)
+        if Path::new(".git/packed-refs").exists() {
+            println!("cargo:rerun-if-changed=.git/packed-refs");
+        }
+        // If you want rebuilds when tags change (for GIT_TAG), watch tag storage too:
+        // lightweight/annotated tags may live in packed-refs as well
+        println!("cargo:rerun-if-changed=.git/refs/tags");
+
+        // Optional: allow turning this off in CI
+        println!("cargo:rerun-if-env-changed=GIT_INFO_DISABLE");
+        if std::env::var_os("GIT_INFO_DISABLE").is_some() {
+            return;
+        }
+
+        // Git tag (may be empty if no tag points at HEAD)
+        let git_tag = run_git(&["tag", "--points-at", "HEAD"]).unwrap_or_else(|| "None".into());
+        println!("cargo:rustc-env=GIT_TAG={}", git_tag);
+
+        // Git hash
+        let git_hash = run_git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "None".into());
+        println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+
+        // Git commit message
+        let git_message =
+            run_git(&["show", "-s", "--format=%s", "HEAD"]).unwrap_or_else(|| "None".into());
+        println!("cargo:rustc-env=GIT_MESSAGE={}", git_message);
+
+        // Git commit date
+        let git_date =
+            run_git(&["show", "-s", "--format=%ci", "HEAD"]).unwrap_or_else(|| "unknown".into());
+        println!("cargo:rustc-env=GIT_DATE={}", git_date);
     }
-    // Also handle packed refs (some repos store refs here)
-    if Path::new(".git/packed-refs").exists() {
-        println!("cargo:rerun-if-changed=.git/packed-refs");
-    }
-    // If you want rebuilds when tags change (for GIT_TAG), watch tag storage too:
-    // lightweight/annotated tags may live in packed-refs as well
-    println!("cargo:rerun-if-changed=.git/refs/tags");
-
-    // Optional: allow turning this off in CI
-    println!("cargo:rerun-if-env-changed=GIT_INFO_DISABLE");
-    if std::env::var_os("GIT_INFO_DISABLE").is_some() {
-        return;
-    }
-
-    // Git tag (may be empty if no tag points at HEAD)
-    let git_tag = run_git(&["tag", "--points-at", "HEAD"]).unwrap_or_else(|| "None".into());
-    println!("cargo:rustc-env=GIT_TAG={}", git_tag);
-
-    // Git hash
-    let git_hash = run_git(&["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "None".into());
-    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
-
-    // Git commit message
-    let git_message =
-        run_git(&["show", "-s", "--format=%s", "HEAD"]).unwrap_or_else(|| "None".into());
-    println!("cargo:rustc-env=GIT_MESSAGE={}", git_message);
-
-    // Git commit date
-    let git_date =
-        run_git(&["show", "-s", "--format=%ci", "HEAD"]).unwrap_or_else(|| "unknown".into());
-    println!("cargo:rustc-env=GIT_DATE={}", git_date);
 }
 
+#[cfg(target_family = "unix")]
 fn read_cmd(args: &[&str]) -> Option<String> {
     run_git(args)
 }
 
+#[cfg(target_family = "unix")]
 fn run_git(args: &[&str]) -> Option<String> {
     let output = Command::new("git").args(args).output().ok()?;
     if !output.status.success() {

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+fn main() {
+    // Run git to get the current commit hash
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .expect("Failed to execute git");
+
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    // Export it as an environment variable for your code
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
+}

--- a/build.rs
+++ b/build.rs
@@ -6,8 +6,6 @@ use std::process::Command;
 fn main() {
     #[cfg(target_family = "unix")]
     {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
-
         // --- Tell Cargo when to rerun (important!) ---
         // Re-run if the branch HEAD moves.
         println!("cargo:rerun-if-changed=.git/HEAD");

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,30 @@
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    // --- Tell Cargo when to rerun (important!) ---
+    // Re-run if the branch HEAD moves.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    // Re-run if the HEAD points to a branch ref and that ref moves.
+    if let Some(head_ref) = read_cmd(&["symbolic-ref", "-q", "HEAD"]) {
+        // e.g., "refs/heads/main"
+        let ref_path = format!(".git/{}", head_ref.trim());
+        println!("cargo:rerun-if-changed={}", ref_path);
+    }
+    // Also handle packed refs (some repos store refs here)
+    if Path::new(".git/packed-refs").exists() {
+        println!("cargo:rerun-if-changed=.git/packed-refs");
+    }
+    // If you want rebuilds when tags change (for GIT_TAG), watch tag storage too:
+    // lightweight/annotated tags may live in packed-refs as well
+    println!("cargo:rerun-if-changed=.git/refs/tags");
+
+    // Optional: allow turning this off in CI
+    println!("cargo:rerun-if-env-changed=GIT_INFO_DISABLE");
+    if std::env::var_os("GIT_INFO_DISABLE").is_some() {
+        return;
+    }
+
     // Git tag (may be empty if no tag points at HEAD)
     let git_tag = run_git(&["tag", "--points-at", "HEAD"]).unwrap_or_else(|| "None".into());
     println!("cargo:rustc-env=GIT_TAG={}", git_tag);
@@ -18,6 +42,10 @@ fn main() {
     let git_date =
         run_git(&["show", "-s", "--format=%ci", "HEAD"]).unwrap_or_else(|| "unknown".into());
     println!("cargo:rustc-env=GIT_DATE={}", git_date);
+}
+
+fn read_cmd(args: &[&str]) -> Option<String> {
+    run_git(args)
 }
 
 fn run_git(args: &[&str]) -> Option<String> {

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,6 @@
 use std::process::Command;
 
 fn main() {
-    println!("cargo:rerun-if-changed=.git/HEAD");
-    println!("cargo:rerun-if-changed=.git/refs/heads");
-    println!("cargo:rerun-if-changed=.git/refs/tags");
-
     // Git tag (may be empty if no tag points at HEAD)
     let git_tag = run_git(&["tag", "--points-at", "HEAD"]).unwrap_or_else(|| "None".into());
     println!("cargo:rustc-env=GIT_TAG={}", git_tag);

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -106,12 +106,15 @@ impl StoreKey {
 }
 
 fn print_version_info() {
-    info!("BitVMX Client build information:");
-    info!("Version: {}", env!("CARGO_PKG_VERSION"));
-    info!("Commit date: {}", env!("GIT_DATE"));
-    info!("Git hash: {}", env!("GIT_HASH"));
-    info!("Git message: {}", env!("GIT_MESSAGE"));
-    info!("Git tag: {}", env!("GIT_TAG"));
+    #[cfg(target_family = "unix")]
+    {
+        info!("BitVMX Client build information:");
+        info!("Version: {}", env!("CARGO_PKG_VERSION"));
+        info!("Commit date: {}", env!("GIT_DATE"));
+        info!("Git hash: {}", env!("GIT_HASH"));
+        info!("Git message: {}", env!("GIT_MESSAGE"));
+        info!("Git tag: {}", env!("GIT_TAG"));
+    }
 }
 
 impl BitVMX {

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -107,6 +107,9 @@ impl StoreKey {
 
 impl BitVMX {
     pub fn new(config: Config) -> Result<Self, BitVMXError> {
+        info!("BitVMX Version: {}", env!("CARGO_PKG_VERSION"));
+        info!("BitVMX Git hash: {}", env!("GIT_HASH"));
+
         let store = Rc::new(Storage::new(&config.storage)?);
         let key_chain = KeyChain::new(&config, store.clone())?;
         let comms = P2pHandler::new::<LocalAllowList>(

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -105,10 +105,18 @@ impl StoreKey {
     }
 }
 
+fn print_version_info() {
+    info!("BitVMX Client build information:");
+    info!("Version: {}", env!("CARGO_PKG_VERSION"));
+    info!("Commit date: {}", env!("GIT_DATE"));
+    info!("Git hash: {}", env!("GIT_HASH"));
+    info!("Git message: {}", env!("GIT_MESSAGE"));
+    info!("Git tag: {}", env!("GIT_TAG"));
+}
+
 impl BitVMX {
     pub fn new(config: Config) -> Result<Self, BitVMXError> {
-        info!("BitVMX Version: {}", env!("CARGO_PKG_VERSION"));
-        info!("BitVMX Git hash: {}", env!("GIT_HASH"));
+        print_version_info();
 
         let store = Rc::new(Storage::new(&config.storage)?);
         let key_chain = KeyChain::new(&config, store.clone())?;


### PR DESCRIPTION
Print the BitVMX version and git hash when a BitVMX client is created
```
[2m2025-09-24T17:22:39.911726Zbitvmx_client::bitvmxBitVMX Version: 0.1.0
[2m2025-09-24T17:22:39.911782Zbitvmx_client::bitvmxBitVMX Git hash: ffa8ea7
```