### PR TITLE
Cleanup dependencies at Cargo.toml 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ bitvmx-bitcoin-rpc = { path = "../rust-bitvmx-bitcoin-rpc" }
 bitvmx-broker = { path = "../rust-bitvmx-broker", features = [
     "storagebackend",
 ] }
-bitcoind = { path = "../rust-bitcoind" }
 emulator = { path = "../BitVMX-CPU/emulator" }
 bitcoin-script-riscv = { path = "../BitVMX-CPU/bitcoin-script-riscv" }
 bitvmx-cpu-definitions = { path = "../BitVMX-CPU/definitions" }
@@ -56,19 +55,23 @@ bitvmx-job-dispatcher-types = { path = "../rust-bitvmx-job-dispatcher/jobtypes",
 zk-result = { path = "../rust-bitvmx-zk-proof/zk-result" }
 bitvmx-wallet = { path = "../rust-bitvmx-wallet" }
 
-musig2 = { version = "0.2.3", features = ["serde", "rand"] }
-reqwest = "0.12.23"
+[dependencies.reqwest]
+version = "0.12.23"
+optional = true
+
+[dependencies.bitcoind]
+path = "../rust-bitcoind"
+optional = true
 
 [dev-dependencies]
 bollard = "0.11.0"
 futures-util = "0.3"
 bitcoind = { path = "../rust-bitcoind" }
-bitvmx-wallet = { path = "../rust-bitvmx-wallet" }
 
 [features]
 default = ["cardinal", "union"]
 cardinal = []
-union = []
+union = ["reqwest", "bitcoind"]
 testpanic = []
 
 [[example]]

--- a/src/program/protocols/union/types.rs
+++ b/src/program/protocols/union/types.rs
@@ -1,5 +1,5 @@
 use bitcoin::{PublicKey, Txid};
-use musig2::{secp::MaybeScalar, PubNonce};
+use key_manager::musig2::{secp::MaybeScalar, PubNonce};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 


### PR DESCRIPTION
Reqwest and bitcoind are only used in tests and union bitvmx-wallet is now used in the whole app
Remove musig2 dependency, use key_manager::musig2 re-export

WARNING PR https://github.com/FairgateLabs/rust-bitvmx-key-manager/pull/39 needs to be merged FIRST!