### PR TITLE
Prover challenge step

### DIFF
--- a/src/program/protocols/dispute/challenge.rs
+++ b/src/program/protocols/dispute/challenge.rs
@@ -237,6 +237,11 @@ pub fn challenge_scripts(
     match nary_search_type {
         NArySearchType::ConflictStep => {
             for (challenge_name, subnames) in CHALLENGES.iter() {
+                let mut subnames: Vec<(&str, usize)> = subnames.to_vec();
+                // The verifier to challenge needs this variable from the prover so we add it to every challenge
+                // we then drop it in the reverse script
+                subnames.push(("prover_continue", 1));
+
                 let total_len = subnames.iter().map(|(_, size)| *size).sum::<usize>() as u32 * 2;
 
                 let (names_and_keys, alternate_reverse) = if *challenge_name == "input" {
@@ -247,6 +252,7 @@ pub fn challenge_scripts(
                     for i in 1..total_len {
                         stack.move_var_sub_n(all, total_len - i - 1);
                     }
+                    stack.op_2drop(); // drop prover_continue
                     let reverse_script = stack.get_script();
                     (vec![], Some(reverse_script))
                 } else {
@@ -271,6 +277,7 @@ pub fn challenge_scripts(
                 for i in 1..total_len {
                     stack.move_var_sub_n(all, total_len - i - 1);
                 }
+                stack.op_2drop(); // drop prover_continue
                 let reverse_script = stack.get_script();
 
                 context.globals.set_var(
@@ -619,6 +626,9 @@ pub fn challenge_scripts(
         }
         NArySearchType::ReadValueChallenge => {
             for (challenge_name, subnames) in READ_CHALLENGES.iter() {
+                let mut subnames: Vec<(&str, usize)> = subnames.to_vec();
+                subnames.push(("prover_continue2", 1));
+
                 let total_len = subnames.iter().map(|(_, size)| *size).sum::<usize>() as u32 * 2;
 
                 let names_and_keys = subnames
@@ -638,6 +648,7 @@ pub fn challenge_scripts(
                 for i in 1..total_len {
                     stack.move_var_sub_n(all, total_len - i - 1);
                 }
+                stack.op_2drop(); // drop prover_continue2
                 let reverse_script = stack.get_script();
 
                 context.globals.set_var(

--- a/src/program/protocols/dispute/tx_news.rs
+++ b/src/program/protocols/dispute/tx_news.rs
@@ -191,7 +191,8 @@ impl TimeoutDispatchTable {
         table.add_verifier_without_vout(EXECUTE, TimeoutType::timeout_input(EXECUTE));
         table.add_not_apply_not_vout(CHALLENGE, Verifier, to_second_nary);
         table.add_nary_search_table("NARY2", 2, rounds);
-        table.add_classic_to(&last_tx_second_nary, CHALLENGE_READ, Prover);
+        table.add_classic_to(&last_tx_second_nary, GET_HASHES_AND_STEP, Verifier);
+        table.add_classic_to(GET_HASHES_AND_STEP, CHALLENGE_READ, Prover);
         table
     }
 

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -1345,6 +1345,31 @@ fn challenge_equivocation_resign_next2_prover() -> Result<()> {
 fn challenge_equivocation_resign_next2_verifier() -> Result<()> {
     test_challenge(ForcedChallenges::EquivocationResignNext2(Verifier))
 }
+
+#[ignore]
+#[test]
+fn challenge_prover_challenge_step_prover() -> Result<()> {
+    test_challenge(ForcedChallenges::ProverChallengeStep(Prover))
+}
+
+#[ignore]
+#[test]
+fn challenge_prover_challenge_step_verifier() -> Result<()> {
+    test_challenge(ForcedChallenges::ProverChallengeStep(Verifier))
+}
+
+#[ignore]
+#[test]
+fn challenge_prover_challenge_step2_prover() -> Result<()> {
+    test_challenge(ForcedChallenges::ProverChallengeStep2(Prover))
+}
+
+#[ignore]
+#[test]
+fn challenge_prover_challenge_step2_verifier() -> Result<()> {
+    test_challenge(ForcedChallenges::ProverChallengeStep2(Verifier))
+}
+
 // The forced Execution is required for testing because without it, the prover or verifier will not execute directly
 // #[ignore]
 // #[test]


### PR DESCRIPTION
Allow the prover to challenge the selected step by the verifier in both nary searches.

In the first nary search, he can challenge if the selected step is grater or equal to the last_step committed. And, in the second nary search, he can challenge if the selected step is grater than the selected step in the previous nary search. 

It's not valid to select the last_step because the nary search is off by one, and the trace required is the next one to the selected step. If the selected step is last_step, the corresponding trace is for last_step+1, an invalid step.  

Though, it is valid for the verifier to select the same step in both searches. The prover can change his hashes in the second nary search, and the verifier can show that the hash committed in both searches for the same step is different. For the read value challenge, the challenge itself will enforce that they are not the same step.