### PR TITLE
Only allow second nary search for ReadNArySearchValue

### DIFF
--- a/examples/union/setup/dispute_channel_setup.rs
+++ b/examples/union/setup/dispute_channel_setup.rs
@@ -199,6 +199,7 @@ impl DisputeChannelSetup {
             DRP_TIMELOCK_BLOCKS,
             DRP_PROGRAM_DEFINITION.to_string(),
             Some(dispute_config), // FIXME: Remove this setting for production, use 'None' instead.
+            false,
             vec![(PROGRAM_TYPE_DISPUTE_CORE.to_string(), dispute_core_pid)],
             Some(0),
         );

--- a/examples/union/setup/dispute_channel_setup.rs
+++ b/examples/union/setup/dispute_channel_setup.rs
@@ -12,7 +12,7 @@ use bitvmx_client::{
         participant::{CommsAddress, ParticipantRole},
         protocols::{
             dispute::{
-                config::{ConfigResult, ConfigResults, DisputeConfiguration},
+                config::{ConfigResult, ForceFailConfiguration, DisputeConfiguration},
                 TIMELOCK_BLOCKS as DRP_TIMELOCK_BLOCKS,
             },
             union::{
@@ -178,7 +178,8 @@ impl DisputeChannelSetup {
             PROGRAM_TYPE_DRP, drp_id, op_index, wt_index,
         );
 
-        let dispute_config = ConfigResults {
+        let dispute_config = ForceFailConfiguration {
+            prover_force_second_nary: false,
             main: ConfigResult {
                 fail_config_prover: None,
                 fail_config_verifier: None,
@@ -199,7 +200,6 @@ impl DisputeChannelSetup {
             DRP_TIMELOCK_BLOCKS,
             DRP_PROGRAM_DEFINITION.to_string(),
             Some(dispute_config), // FIXME: Remove this setting for production, use 'None' instead.
-            false,
             vec![(PROGRAM_TYPE_DISPUTE_CORE.to_string(), dispute_core_pid)],
             Some(0),
         );

--- a/examples/union/setup/dispute_channel_setup.rs
+++ b/examples/union/setup/dispute_channel_setup.rs
@@ -180,6 +180,7 @@ impl DisputeChannelSetup {
 
         let dispute_config = ForceFailConfiguration {
             prover_force_second_nary: false,
+            fail_input_tx: None,
             main: ConfigResult {
                 fail_config_prover: None,
                 fail_config_verifier: None,

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -25,6 +25,7 @@ pub struct DisputeConfiguration {
     pub timelock_blocks: u16,
     pub program_definition: String,
     pub fail_force_config: Option<ConfigResults>,
+    pub prover_force_second_nary: bool,
     pub notify_protocol: Vec<(String, Uuid)>,
     pub auto_dispatch_input: Option<u8>,
 }
@@ -43,6 +44,7 @@ impl DisputeConfiguration {
         timelock_blocks: u16,
         program_definition: String,
         fail_force_config: Option<ConfigResults>,
+        prover_force_second_nary: bool,
         notify_protocol: Vec<(String, Uuid)>,
         auto_dispatch_input: Option<u8>,
     ) -> Self {
@@ -59,6 +61,7 @@ impl DisputeConfiguration {
             fail_force_config,
             notify_protocol,
             auto_dispatch_input,
+            prover_force_second_nary,
         }
     }
 

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -98,6 +98,7 @@ pub struct ConfigResult {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct ForceFailConfiguration {
     pub prover_force_second_nary: bool,
+    pub fail_input_tx: Option<String>,
     pub main: ConfigResult,
     pub read: ConfigResult, // for read challenge (2nd n-ary search)
 }
@@ -117,6 +118,7 @@ impl Default for ForceFailConfiguration {
     fn default() -> Self {
         Self {
             prover_force_second_nary: false,
+            fail_input_tx: None,
             main: ConfigResult::default(),
             read: ConfigResult::default(),
         }

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -24,8 +24,7 @@ pub struct DisputeConfiguration {
     pub verifier_enablers: Vec<OutputType>,
     pub timelock_blocks: u16,
     pub program_definition: String,
-    pub fail_force_config: Option<ConfigResults>,
-    pub prover_force_second_nary: bool,
+    pub fail_force_config: Option<ForceFailConfiguration>,
     pub notify_protocol: Vec<(String, Uuid)>,
     pub auto_dispatch_input: Option<u8>,
 }
@@ -43,8 +42,7 @@ impl DisputeConfiguration {
         verifier_enablers: Vec<OutputType>,
         timelock_blocks: u16,
         program_definition: String,
-        fail_force_config: Option<ConfigResults>,
-        prover_force_second_nary: bool,
+        fail_force_config: Option<ForceFailConfiguration>,
         notify_protocol: Vec<(String, Uuid)>,
         auto_dispatch_input: Option<u8>,
     ) -> Self {
@@ -61,7 +59,6 @@ impl DisputeConfiguration {
             fail_force_config,
             notify_protocol,
             auto_dispatch_input,
-            prover_force_second_nary,
         }
     }
 
@@ -99,7 +96,8 @@ pub struct ConfigResult {
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
-pub struct ConfigResults {
+pub struct ForceFailConfiguration {
+    pub prover_force_second_nary: bool,
     pub main: ConfigResult,
     pub read: ConfigResult, // for read challenge (2nd n-ary search)
 }
@@ -115,9 +113,10 @@ impl Default for ConfigResult {
     }
 }
 
-impl Default for ConfigResults {
+impl Default for ForceFailConfiguration {
     fn default() -> Self {
         Self {
+            prover_force_second_nary: false,
             main: ConfigResult::default(),
             read: ConfigResult::default(),
         }

--- a/src/program/protocols/dispute/execution.rs
+++ b/src/program/protocols/dispute/execution.rs
@@ -6,7 +6,7 @@ use bitvmx_cpu_definitions::challenge::{
     ChallengeType, EmulatorResultType, ProverFinalTraceType, ProverHashesAndStepType,
 };
 use emulator::constants::REGISTERS_BASE_ADDRESS;
-use tracing::info;
+use tracing::{error, info};
 use uuid::Uuid;
 
 use crate::{
@@ -71,12 +71,13 @@ pub fn execution_result(
                 .unwrap_or(context.globals.get_var(id, "current_round")?.unwrap()) // 1st n-ary search
                 .number()? as u8;
 
-            let (nary_prover, prover_hash) =
-                if context.globals.get_var(id, "current_round2")?.is_some() {
-                    ("NARY2_PROVER", "prover_hash2") // 2nd n-ary search
-                } else {
-                    ("NARY_PROVER", "prover_hash") // 1st n-ary search
-                };
+            let is_second_nary_search = context.globals.get_var(id, "current_round2")?.is_some();
+
+            let (nary_prover, prover_hash) = if is_second_nary_search {
+                ("NARY2_PROVER", "prover_hash2") // 2nd n-ary search
+            } else {
+                ("NARY_PROVER", "prover_hash") // 1st n-ary search
+            };
 
             assert_eq!(save_round, *round);
             for (i, h) in hashes.iter().enumerate() {
@@ -87,13 +88,25 @@ pub fn execution_result(
                     h,
                 )?;
             }
-            let (tx, sp) = drp.get_tx_with_speedup_data(
+
+            let tx_with_speedup = drp.get_tx_with_speedup_data(
                 context,
                 &format!("{}_{}", nary_prover, round),
                 0,
                 0,
                 true,
-            )?;
+            );
+
+            if is_second_nary_search
+                && *round == 2 // second nary search starts at the second round for the prover, since the first hashes are shared with the first nary search
+                && matches!(tx_with_speedup, Err(BitVMXError::KeysNotFound(_)))
+            {
+                error!("Could not start second nary search, this is expected if the verifier didn't select the ReadNAryValue Challenge since we don't have the required signature for verifier_selection_bits2_1 to continue");
+                return Ok(());
+            }
+
+            let (tx, sp) = tx_with_speedup?;
+
             info!("Dispatching tx {:?}", tx);
             context.bitcoin_coordinator.dispatch(
                 tx,

--- a/src/program/protocols/dispute/mod.rs
+++ b/src/program/protocols/dispute/mod.rs
@@ -851,6 +851,26 @@ impl ProtocolHandler for DisputeResolutionProtocol {
                 .map(|h| format!("prover_hash2_{}_{}", i, h))
                 .collect::<Vec<_>>();
 
+            let winternitz_check = if i == 2 {
+                Self::winternitz_check_cosigned_input_script(
+                    agg_or_prover,
+                    sign_mode,
+                    &keys,
+                    &vec![
+                        &vars.iter().map(|s| s.as_str()).collect(),
+                        &vec!["verifier_selection_bits2_1"],
+                    ],
+                    None,
+                )?
+            } else {
+                Self::winternitz_check(
+                    agg_or_prover,
+                    sign_mode,
+                    &keys[0],
+                    &vars.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
+                )?
+            };
+
             self.add_connection_with_scripts(
                 context,
                 aggregated,
@@ -861,12 +881,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
                 &prev,
                 &next,
                 &claim_verifier,
-                Self::winternitz_check(
-                    agg_or_prover,
-                    sign_mode,
-                    &keys[0],
-                    &vars.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-                )?,
+                winternitz_check,
                 (&prover_speedup_pub, &verifier_speedup_pub),
             )?;
             amount = self.checked_sub(amount, fee)?;

--- a/src/program/protocols/dispute/mod.rs
+++ b/src/program/protocols/dispute/mod.rs
@@ -1653,7 +1653,7 @@ impl DisputeResolutionProtocol {
         stack.get_script()
     }
 
-    fn get_validate_selection_bits_script(max_bits: u8) -> ScriptBuf {
+    pub fn get_validate_selection_bits_script(max_bits: u8) -> ScriptBuf {
         let mut stack = StackTracker::new();
         let selection_bits = stack.define(2, "verifier_selection_bits");
 

--- a/src/program/protocols/dispute/tx_news.rs
+++ b/src/program/protocols/dispute/tx_news.rs
@@ -8,7 +8,7 @@ use crate::{
             dispute::{
                 action_wins, action_wins_prefix,
                 challenge::READ_VALUE_NARY_SEARCH_CHALLENGE,
-                config::{ConfigResults, DisputeConfiguration},
+                config::{DisputeConfiguration, ForceFailConfiguration},
                 input_handler::{
                     get_txs_configuration, set_input, set_input_u64, unify_inputs, unify_witnesses,
                 },
@@ -1077,7 +1077,7 @@ pub fn handle_tx_news(
                 }
             }
             _ => {
-                if config.prover_force_second_nary {
+                if fail_force_config.prover_force_second_nary {
                     // for testing purposes we will try to start the second nary search but it should fail
                     let selection_bits = 0;
                     handle_nary_verifier(
@@ -1259,7 +1259,7 @@ fn handle_nary_verifier(
     vout: Option<u32>,
     tx_status: &TransactionStatus,
     current_height: u32,
-    fail_force_config: &ConfigResults,
+    fail_force_config: &ForceFailConfiguration,
     selection_bits: &str,             // "selection_bits"
     prev_name: &str,                  // COMMITMENT
     post_name: &str,                  // EXECUTE
@@ -1382,7 +1382,7 @@ fn handle_nary_prover(
     tx_id: Txid,
     vout: Option<u32>,
     tx_status: &TransactionStatus,
-    fail_force_config: &ConfigResults,
+    fail_force_config: &ForceFailConfiguration,
     strip_prefix: &str,               // "NARY_PROVER_"
     prover_hash: &str,                // "prover_hash"
     nary_search_type: NArySearchType, // ConflictStep

--- a/src/program/protocols/dispute/tx_news.rs
+++ b/src/program/protocols/dispute/tx_news.rs
@@ -1019,6 +1019,13 @@ pub fn handle_tx_news(
             None,
         )?;
 
+        let params = program_context
+            .globals
+            .get_var(&drp.ctx.id, &timeout_input_tx(&name))?
+            .unwrap()
+            .vec_number()?;
+        let timeout_leaf = params[1];
+
         let read_value_nary_search_leaf = program_context
             .globals
             .get_var(
@@ -1029,6 +1036,9 @@ pub fn handle_tx_news(
             .number()? as u32;
 
         match leaf {
+            l if l == timeout_leaf => {
+                info!("Prover consumed the timeout input for {name}");
+            }
             l if l == read_value_nary_search_leaf => {
                 let mut expected_names: Vec<&str> = READ_VALUE_NARY_SEARCH_CHALLENGE
                     .iter()

--- a/tests/common/dispute.rs
+++ b/tests/common/dispute.rs
@@ -63,6 +63,7 @@ pub enum ForcedChallenges {
     EquivocationResignNext(ParticipantRole),
     ProverChallengeStep(ParticipantRole),
     VerifierOutOfBoundsBits,
+    VerifierOutOfBoundsBitsInChallenge,
     // 2nd n-ary search
     ReadValue(ParticipantRole),
     CorrectHash(ParticipantRole),
@@ -107,7 +108,7 @@ impl ForcedChallenges {
             | EquivocationResignNext2(role) => Some(role.clone()),
             No | Execution | Personalized(_) => None,
             ProverForceSecondNary => Some(ParticipantRole::Prover),
-            VerifierOutOfBoundsBits => Some(ParticipantRole::Verifier),
+            VerifierOutOfBoundsBits | VerifierOutOfBoundsBitsInChallenge => Some(ParticipantRole::Verifier),
         }
     }
 }
@@ -996,6 +997,12 @@ pub fn get_fail_force_config(fail_force_config: ForcedChallenges) -> ForceFailCo
             ParticipantRole::Verifier,
             FailConfiguration::new_fail_selection_bits(Some(2), 16),
             ForceChallenge::No,
+            ForceCondition::Always,
+        ),
+        ForcedChallenges::VerifierOutOfBoundsBitsInChallenge => get_config_simple(
+            ParticipantRole::Verifier,
+            FailConfiguration::new_fail_selection_bits(None, 16),
+            ForceChallenge::ReadValueNArySearch,
             ForceCondition::Always,
         ),
         ForcedChallenges::No => ForceFailConfiguration::default(),

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -16,8 +16,7 @@ use bitvmx_client::program::participant::{
 };
 use bitvmx_client::program::protocols::dispute::config::{ConfigResult, ForceFailConfiguration};
 use bitvmx_client::program::protocols::dispute::{
-    action_wins, input_tx_name, program_input, program_input_prev_prefix,
-    program_input_prev_protocol, protocol_cost,
+    COMMITMENT, POST_COMMITMENT, PRE_COMMITMENT, action_wins, input_tx_name, program_input, program_input_prev_prefix, program_input_prev_protocol, protocol_cost
 };
 use bitvmx_client::program::variables::{VariableTypes, WitnessTypes};
 use bitvmx_client::types::{
@@ -935,6 +934,7 @@ fn test_const_fail_input() -> Result<()> {
 
     let fail_config = ForceFailConfiguration {
         prover_force_second_nary: false,
+        fail_input_tx: None,
         main: main_config,
         read: ConfigResult::default(),
     };
@@ -1430,6 +1430,79 @@ fn challenge_verifier_out_of_bounds_bits() -> Result<()> {
 fn challenge_verifier_out_of_bounds_bits_in_challenge() -> Result<()> {
     test_challenge(ForcedChallenges::VerifierOutOfBoundsBitsInChallenge)
 }
+
+#[ignore]
+#[test]
+fn test_input_timeout_hashes_prover() -> Result<()> {
+    test_challenge(ForcedChallenges::InputTimeOut("NARY_PROVER_1".to_string(), ParticipantRole::Prover))
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_pre_commitment_verifier() -> Result<()> {
+    test_challenge(ForcedChallenges::InputTimeOut(PRE_COMMITMENT.to_string(), ParticipantRole::Verifier))
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_commitment_prover() -> Result<()> {
+    test_challenge(ForcedChallenges::InputTimeOut(COMMITMENT.to_string(), ParticipantRole::Prover))
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_post_commitment_verifier() -> Result<()> {
+    test_challenge(ForcedChallenges::InputTimeOut(POST_COMMITMENT.to_string(), ParticipantRole::Verifier))
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_input_prover() -> Result<()> {
+    test_challenge(ForcedChallenges::InputTimeOut(input_tx_name(0), ParticipantRole::Prover))
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_input_prover_with_previous() -> Result<()> {
+    test_all_aux(
+        false,
+        Network::Regtest,
+        Some("./verifiers/add-test-with-previous-wots.yaml".to_string()),
+        Some(("00000002", 1, "00000003", 2).into()),
+        Some(ForcedChallenges::InputTimeOut(input_tx_name(2), ParticipantRole::Prover)),
+        None,
+    )?;
+    Ok(())
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_input_verifier() -> Result<()> {
+    test_all_aux(
+        false,
+        Network::Regtest,
+        Some("../BitVMX-CPU/docker-riscv32/riscv32/build/hello-world-verifier.yaml".to_string()),
+        Some(InputType::Participant("11111111".to_string(), Verifier)),
+        Some(ForcedChallenges::InputTimeOut(input_tx_name(0), ParticipantRole::Verifier)),
+        None,
+    )?;
+    Ok(())
+}
+
+#[ignore]
+#[test]
+fn test_input_timeout_input_prover_cosign() -> Result<()> {
+    test_all_aux(
+        false,
+        Network::Regtest,
+        Some("../BitVMX-CPU/docker-riscv32/riscv32/build/hello-world-verifier.yaml".to_string()),
+        Some(InputType::Participant("11111111".to_string(), Verifier)),
+        Some(ForcedChallenges::InputTimeOut(input_tx_name(1), ParticipantRole::Prover)),
+        None,
+    )?;
+    Ok(())
+}
+
 // The forced Execution is required for testing because without it, the prover or verifier will not execute directly
 // #[ignore]
 // #[test]

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -14,7 +14,7 @@ use bitvmx_client::program::participant::{
     CommsAddress,
     ParticipantRole::{self, Prover, Verifier},
 };
-use bitvmx_client::program::protocols::dispute::config::{ConfigResult, ConfigResults};
+use bitvmx_client::program::protocols::dispute::config::{ConfigResult, ForceFailConfiguration};
 use bitvmx_client::program::protocols::dispute::{
     action_wins, input_tx_name, program_input, program_input_prev_prefix,
     program_input_prev_protocol, protocol_cost,
@@ -933,7 +933,8 @@ fn test_const_fail_input() -> Result<()> {
         force_condition: ForceCondition::ValidInputWrongStepOrHash,
     };
 
-    let fail_config = ConfigResults {
+    let fail_config = ForceFailConfiguration {
+        prover_force_second_nary: false,
         main: main_config,
         read: ConfigResult::default(),
     };

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -1424,6 +1424,12 @@ fn challenge_prover_force_second_nary() -> Result<()> {
 fn challenge_verifier_out_of_bounds_bits() -> Result<()> {
     test_challenge(ForcedChallenges::VerifierOutOfBoundsBits)
 }
+
+#[ignore]
+#[test]
+fn challenge_verifier_out_of_bounds_bits_in_challenge() -> Result<()> {
+    test_challenge(ForcedChallenges::VerifierOutOfBoundsBitsInChallenge)
+}
 // The forced Execution is required for testing because without it, the prover or verifier will not execute directly
 // #[ignore]
 // #[test]

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -1412,6 +1412,17 @@ fn challenge_prover_challenge_step2_verifier() -> Result<()> {
     test_challenge(ForcedChallenges::ProverChallengeStep2(Verifier))
 }
 
+#[ignore]
+#[test]
+fn challenge_prover_force_second_nary() -> Result<()> {
+    test_challenge(ForcedChallenges::ProverForceSecondNary)
+}
+
+#[ignore]
+#[test]
+fn challenge_verifier_out_of_bounds_bits() -> Result<()> {
+    test_challenge(ForcedChallenges::VerifierOutOfBoundsBits)
+}
 // The forced Execution is required for testing because without it, the prover or verifier will not execute directly
 // #[ignore]
 // #[test]


### PR DESCRIPTION
Also adds some checks in handle_tx_news to ignore the transaction if it's the timeout leaf