### PR TITLE
[trigger-confirmation-v0.5.1]  Pass new confirmation trigger param to every method.

### DIFF
--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -1241,6 +1241,7 @@ impl BitVMXApi for BitVMX {
             .monitor(TypesToMonitor::Transactions(
                 vec![txid],
                 Context::RequestId(id, from).to_string()?,
+                None, // Receive news on every confirmation.
             ))?;
 
         Ok(())
@@ -1254,7 +1255,7 @@ impl BitVMXApi for BitVMX {
         // Enable RSK pegin transaction monitoring
         self.program_context
             .bitcoin_coordinator
-            .monitor(TypesToMonitor::RskPeginTransaction)?;
+            .monitor(TypesToMonitor::RskPegin(None))?;
         Ok(())
     }
 
@@ -1324,6 +1325,7 @@ impl BitVMXApi for BitVMX {
             None,
             Context::RequestId(id, from).to_string()?,
             None,
+            None, // Receive news on every confirmation.
         )?;
 
         Ok(())

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -695,8 +695,11 @@ impl Program {
                     self.protocol.get_transactions_to_monitor(program_context)?;
 
                 let context = Context::ProgramId(self.program_id);
-                let txs_to_monitor =
-                    TypesToMonitor::Transactions(txns_to_monitor.clone(), context.to_string()?);
+                let txs_to_monitor = TypesToMonitor::Transactions(
+                    txns_to_monitor.clone(),
+                    context.to_string()?,
+                    None,
+                );
 
                 program_context
                     .bitcoin_coordinator
@@ -707,8 +710,12 @@ impl Program {
                         "Monitoring vout {} of txid {} for program {}",
                         vout, txid, self.program_id
                     );
-                    let vout_to_monitor =
-                        TypesToMonitor::SpendingUTXOTransaction(txid, vout, context.to_string()?);
+                    let vout_to_monitor = TypesToMonitor::SpendingUTXOTransaction(
+                        txid,
+                        vout,
+                        context.to_string()?,
+                        None, // Receive news on every confirmation.
+                    );
 
                     program_context
                         .bitcoin_coordinator
@@ -845,7 +852,8 @@ impl Program {
             tx_to_dispatch,
             speedup,
             context.to_string()?,
-            None,
+            None, // Dispatch immediately
+            None, // Receive news on every confirmation.
         )?;
 
         Ok(())

--- a/src/program/protocols/cardinal/slot.rs
+++ b/src/program/protocols/cardinal/slot.rs
@@ -275,6 +275,7 @@ impl ProtocolHandler for SlotProtocol {
                     Some(speedup_data),
                     Context::ProgramId(self.ctx.id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
 
                 let total_operators = program_context
@@ -293,6 +294,7 @@ impl ProtocolHandler for SlotProtocol {
                             txid,
                             i + 2, // the first stop is at pos 2
                             Context::ProgramId(self.ctx.id).to_string()?,
+                            None, // Receive news on every confirmation.
                         ),
                     )?;
                 }
@@ -368,6 +370,7 @@ impl ProtocolHandler for SlotProtocol {
                             Some(speedup_data),
                             Context::ProgramId(self.ctx.id).to_string()?,
                             None,
+                            None, // Receive news on every confirmation.
                         )?;
                     } else {
                         info!("The stop for the operator {} has been consumed", i);
@@ -405,6 +408,7 @@ impl ProtocolHandler for SlotProtocol {
                         Some(speedup_data),
                         Context::ProgramId(self.ctx.id).to_string()?,
                         None,
+                        None, // Receive news on every confirmation.
                     )?;
                 }
             }
@@ -445,6 +449,7 @@ impl ProtocolHandler for SlotProtocol {
                 Some(speedup_data),
                 Context::ProgramId(self.ctx.id).to_string()?,
                 Some(tx_status.block_info.unwrap().height + timelock_blocks),
+                None, // Receive news on every confirmation.
             )?;
         }
 

--- a/src/program/protocols/dispute/execution.rs
+++ b/src/program/protocols/dispute/execution.rs
@@ -48,6 +48,7 @@ pub fn execution_result(
                 Some(sp),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
         EmulatorResultType::VerifierCheckExecutionResult { step } => {
@@ -100,6 +101,7 @@ pub fn execution_result(
                 Some(sp),
                 Context::ProgramId(*id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
         EmulatorResultType::VerifierChooseSegmentResult { v_decision, round } => {
@@ -137,6 +139,7 @@ pub fn execution_result(
                 Some(sp),
                 Context::ProgramId(*id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
         EmulatorResultType::ProverFinalTraceResult { prover_final_trace } => {
@@ -150,6 +153,7 @@ pub fn execution_result(
                     Some(sp),
                     Context::ProgramId(*id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
             } else {
                 let (final_trace, resigned_step_hash, resigned_next_hash, conflict_step) =
@@ -267,6 +271,7 @@ pub fn execution_result(
                     Some(sp),
                     Context::ProgramId(*id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
             }
         }
@@ -305,6 +310,7 @@ pub fn execution_result(
                 Some(sp),
                 Context::ProgramId(*id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
         EmulatorResultType::ProverGetHashesAndStepResult {
@@ -320,6 +326,7 @@ pub fn execution_result(
                     Some(sp),
                     Context::ProgramId(*id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
             } else {
                 let (resigned_step_hash, resigned_next_hash, write_step) =
@@ -341,6 +348,7 @@ pub fn execution_result(
                     Some(sp),
                     Context::ProgramId(*id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
             }
         }

--- a/src/program/protocols/dispute/tx_news.rs
+++ b/src/program/protocols/dispute/tx_news.rs
@@ -60,6 +60,7 @@ fn dispatch_timeout_tx(
         Some(speedup_data),
         Context::ProgramId(drp.ctx.id).to_string()?,
         Some(current_height + timelock_blocks),
+        None, // Receive news on every confirmation.
     )?;
     Ok(())
 }
@@ -413,7 +414,7 @@ fn cancel_to_tx(
     info!("Cancel timeout tx: {}", tx_to_cancel);
     let tx_id = drp.get_transaction_id_by_name(&tx_to_cancel)?;
     program_context.bitcoin_coordinator.cancel(
-        bitcoin_coordinator::TypesToMonitor::Transactions(vec![tx_id], String::default()),
+        bitcoin_coordinator::TypesToMonitor::Transactions(vec![tx_id], String::default(), None),
     )?;
     Ok(())
 }
@@ -452,6 +453,7 @@ fn auto_claim_start(
                 Some(speedup_data),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
     }
@@ -495,6 +497,7 @@ fn claim_state_handle(
                 Some(speedup_data),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 Some(current_height + timelock_blocks),
+                None, // Receive news on every confirmation.
             )?;
         }
         //other start
@@ -515,6 +518,7 @@ fn claim_state_handle(
                 Some(speedup_data),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
     }
@@ -546,6 +550,7 @@ fn claim_state_handle(
                 Some(speedup_data),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
     }
@@ -663,6 +668,7 @@ pub fn handle_tx_news(
                 speedup,
                 Context::ProgramId(drp.context().id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
     }
@@ -707,6 +713,7 @@ pub fn handle_tx_news(
                 Some(sp),
                 Context::ProgramId(drp.ctx.id).to_string()?,
                 None,
+                None, // Receive news on every confirmation.
             )?;
         }
         if idx == last_tx_id as u32 {
@@ -719,6 +726,7 @@ pub fn handle_tx_news(
                     Some(sp),
                     Context::ProgramId(drp.ctx.id).to_string()?,
                     None,
+                    None, // Receive news on every confirmation.
                 )?;
             } else {
                 //Prover
@@ -817,6 +825,7 @@ pub fn handle_tx_news(
             Some(sp),
             Context::ProgramId(drp.ctx.id).to_string()?,
             None,
+            None, // Receive news on every confirmation.
         )?;
     }
 
@@ -1191,6 +1200,7 @@ pub fn handle_tx_news(
             Some(speedup_data),
             Context::ProgramId(drp.ctx.id).to_string()?,
             Some(current_height + 2 * timelock_blocks as u32),
+            None, // Receive news on every confirmation.
         )?;
     }
 
@@ -1204,6 +1214,7 @@ pub fn handle_tx_news(
             Some(speedup_data),
             Context::ProgramId(drp.ctx.id).to_string()?,
             None,
+            None, // Receive news on every confirmation.
         )?;
     }
 

--- a/src/program/protocols/union/advance_funds.rs
+++ b/src/program/protocols/union/advance_funds.rs
@@ -366,7 +366,8 @@ impl AdvanceFundsProtocol {
             tx.clone(),
             speedup,
             format!("dispute_core_setup_{}:{}", self.ctx.id, tx_name), // Context string
-            None,                                                      // Dispatch immediately
+            None,
+            None, // Receive news on every confirmation.
         )?;
 
         info!("{} dispatched with txid: {}", tx_name, txid);
@@ -405,6 +406,7 @@ impl AdvanceFundsProtocol {
             speedup,
             tx_name.clone(), // Context string
             block_height,    // Dispatch immediately
+            None,            // Receive news on every confirmation.
         )?;
 
         info!("{} dispatched with txid: {}", tx_name, txid);
@@ -516,7 +518,8 @@ impl AdvanceFundsProtocol {
             tx,
             speedup,
             format!("advance_funds_{}:{}", self.ctx.id, ADVANCE_FUNDS_TX), // Context string
-            None,                                                          // Dispatch immediately
+            None,
+            None, // Receive news on every confirmation.
         )?;
 
         info!("{} dispatched with txid: {}", ADVANCE_FUNDS_TX, txid);

--- a/src/program/protocols/union/dispute_core.rs
+++ b/src/program/protocols/union/dispute_core.rs
@@ -1899,6 +1899,7 @@ impl DisputeCoreProtocol {
             speedup,
             format!("dispute_core_claim_gate_{}:{}", self.ctx.id, tx_name),
             action.block_height(),
+            None, // Receive news on every confirmation.
         )?;
 
         info!(
@@ -1943,6 +1944,7 @@ impl DisputeCoreProtocol {
                 speedup,
                 format!("dispute_core_start_ch_{}:{}", self.ctx.id, tx_name),
                 None,
+                None, // Receive news on every confirmation.
             )?;
 
             info!(
@@ -2251,9 +2253,13 @@ impl DisputeCoreProtocol {
         let (tx, speedup) = protocol.get_transaction_by_name(&init_challenge_name, context)?;
         let txid = tx.compute_txid();
 
-        context
-            .bitcoin_coordinator
-            .dispatch(tx, speedup, init_challenge_name.clone(), None)?;
+        context.bitcoin_coordinator.dispatch(
+            tx,
+            speedup,
+            init_challenge_name.clone(),
+            None,
+            None,
+        )?;
 
         info!(
             id = self.ctx.my_idx,
@@ -2691,6 +2697,7 @@ impl DisputeCoreProtocol {
             speedup,
             format!("dispute_core_{}:{}", self.ctx.id, tx_name),
             tx_type.block_height(),
+            None, // Receive news on every confirmation.
         )?;
 
         info!(

--- a/src/program/protocols/union/full_penalization.rs
+++ b/src/program/protocols/union/full_penalization.rs
@@ -1233,7 +1233,8 @@ impl FullPenalizationProtocol {
                 tx,
                 speedup,
                 format!("full_penalization_{}:{}", self.ctx.id, tx_name),
-                None,
+                None, // Receive news on every confirmation.
+                None, // Dispatch immediately
             )?;
 
             info!(

--- a/src/program/protocols/union/reject_pegin.rs
+++ b/src/program/protocols/union/reject_pegin.rs
@@ -172,7 +172,8 @@ impl ProtocolHandler for RejectPegInProtocol {
             tx,
             speedup,
             format!("reject_pegin_{}:{}", self.ctx.id, REJECT_PEGIN_TX), // Context string
-            None,                                                        // Dispatch immediately
+            None, // Receive news on every confirmation.
+            None, // Dispatch immediately
         )?;
 
         info!(

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -3,7 +3,10 @@ use anyhow::Result;
 use bitcoin::{Amount, Network};
 use bitcoin_coordinator::coordinator::{BitcoinCoordinator, BitcoinCoordinatorApi};
 use bitcoin_coordinator::types::CoordinatorNews;
-use bitcoind::{bitcoind::{Bitcoind, BitcoindFlags}, config::BitcoindConfig};
+use bitcoind::{
+    bitcoind::{Bitcoind, BitcoindFlags},
+    config::BitcoindConfig,
+};
 use bitvmx_bitcoin_rpc::bitcoin_client::{BitcoinClient, BitcoinClientApi};
 use bitvmx_broker::channel::channel::DualChannel;
 use bitvmx_broker::identification::allow_list::AllowList;
@@ -357,7 +360,7 @@ impl TestHelper {
                     fallback_fee: 0.0002,
                 }),
             );
-            
+
             bitcoind_instance.start()?;
             Some(bitcoind_instance)
         };
@@ -1045,8 +1048,8 @@ fn retry_failed_txs_test() -> Result<()> {
         Some(settings.clone()),
     )?);
 
-    coordinator.dispatch(tx1, None, "test_1".to_string(), None)?;
-    coordinator.dispatch(tx2, None, "test_2".to_string(), None)?;
+    coordinator.dispatch(tx1, None, "test_1".to_string(), None, None)?;
+    coordinator.dispatch(tx2, None, "test_2".to_string(), None, None)?;
 
     for _ in 0..10 {
         coordinator.tick()?;


### PR DESCRIPTION
## Changes
Added support for sending monitors with a new parameter: trigger confirmations.
Once a monitor reaches this confirmation threshold, a news event is emitted and will not be sent again.


IMPORTANT: This branch should be merge with:
- [Coordinator PR](https://github.com/FairgateLabs/rust-bitcoin-coordinator/pull/59)
- [Monitor PR](https://github.com/FairgateLabs/rust-bitvmx-transaction-monitor/pull/46)