### PR TITLE
Fix pending queue starvation with retry policy and broker rate limiting

### DIFF
--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -200,7 +200,7 @@ impl BitVMX {
         let timestamp_verifier =
             TimestampVerifier::new(timestamp_config.enabled, timestamp_config.max_drift_ms);
 
-        let message_queue = MessageQueue::new(store.clone(), RetryPolicy::default());
+        let message_queue = MessageQueue::new(store.clone(), RetryPolicy::default()?);
 
         Ok(Self {
             config,

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -200,7 +200,7 @@ impl BitVMX {
         let timestamp_verifier =
             TimestampVerifier::new(timestamp_config.enabled, timestamp_config.max_drift_ms);
 
-        let message_queue = MessageQueue::new(store.clone(), RetryPolicy::default()?);
+        let message_queue = MessageQueue::new(store.clone(), RetryPolicy::default());
 
         Ok(Self {
             config,

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -1,4 +1,5 @@
 use crate::config::ComponentsConfig;
+use crate::message_queue::QueuedMessage;
 use crate::ping_helper::{JobDispatcherType, PingHelper};
 use crate::program::program::is_active_program;
 use crate::program::protocols::protocol_handler::ProtocolHandler;
@@ -441,14 +442,10 @@ impl BitVMX {
         Ok(true)
     }
 
-    pub fn process_msg(
-        &mut self,
-        identifier: Identifier,
-        msg: Vec<u8>,
-        is_new_message: bool,
-    ) -> Result<(), BitVMXError> {
+    pub fn process_msg(&mut self, msg: QueuedMessage) -> Result<(), BitVMXError> {
+        let is_new_message = msg.retries == 0;
         let (version, msg_type, program_id, data, timestamp, signature) =
-            deserialize_msg(msg.clone())?;
+            deserialize_msg(msg.data.clone())?;
 
         // Handle Broadcasted messages specially - they contain original messages to process recursively
         if msg_type == CommsMessageType::Broadcasted {
@@ -458,7 +455,7 @@ impl BitVMX {
                 .leader_broadcast_helper
                 .process_broadcasted_message(
                     &self.program_context,
-                    identifier,
+                    msg.identifier,
                     program_id,
                     data,
                     &self.message_queue,
@@ -471,7 +468,7 @@ impl BitVMX {
         );
         if !is_verification_msg {
             let verified = self.verify_message_signature(
-                &identifier,
+                &msg.identifier,
                 &program_id,
                 &version,
                 &msg_type,
@@ -484,26 +481,27 @@ impl BitVMX {
                     "Buffering message due to missing verification key: {:?} {:?}",
                     program_id, msg_type
                 );
-                self.message_queue.push_back(identifier.to_string(), msg)?;
+                self.message_queue.push_back(msg)?;
                 return Ok(());
             }
         }
         if is_new_message {
             self.timestamp_verifier
-                .ensure_fresh(&identifier.pubkey_hash, timestamp)?;
+                .ensure_fresh(&msg.identifier.pubkey_hash, timestamp)?;
         }
-        let (program, collaboration, peer_address) =
-            if let Some(program) = self.load_program(&program_id).ok() {
-                let peer_address = program.get_address_from_pubkey_hash(&identifier.pubkey_hash)?;
+        let (program, collaboration, peer_address) = if let Some(program) =
+            self.load_program(&program_id).ok()
+        {
+            let peer_address = program.get_address_from_pubkey_hash(&msg.identifier.pubkey_hash)?;
 
-                (Some(program), None, Some(peer_address))
-            } else if let Some(collaboration) = self.get_collaboration(&program_id)? {
-                let peer_address =
-                    collaboration.get_address_from_pubkey_hash(&identifier.pubkey_hash)?;
-                (None, Some(collaboration), Some(peer_address))
-            } else {
-                (None, None, None)
-            };
+            (Some(program), None, Some(peer_address))
+        } else if let Some(collaboration) = self.get_collaboration(&program_id)? {
+            let peer_address =
+                collaboration.get_address_from_pubkey_hash(&msg.identifier.pubkey_hash)?;
+            (None, Some(collaboration), Some(peer_address))
+        } else {
+            (None, None, None)
+        };
 
         let message_consumed = match peer_address {
             Some(peer_address) => {
@@ -563,11 +561,11 @@ impl BitVMX {
 
         if message_consumed {
             self.timestamp_verifier
-                .record(&identifier.pubkey_hash, timestamp);
+                .record(&msg.identifier.pubkey_hash, timestamp);
         } else {
             // Message needs to be buffered (not processed or program/collaboration not found)
             info!("Pending message to back: {:?}", msg_type);
-            self.message_queue.push_back(identifier.to_string(), msg)?;
+            self.message_queue.push_back(msg)?;
         }
         Ok(())
     }
@@ -577,17 +575,8 @@ impl BitVMX {
             return Ok(());
         }
 
-        if let Some((identifier_str, msg)) = self.message_queue.pop_front()? {
-            // Parse the identifier string back to Identifier
-            // All messages in the queue are stored as Identifier strings (from identifier.to_string())
-            let identifier = identifier_str.parse::<Identifier>().map_err(|e| {
-                error!(
-                    "Failed to parse Identifier from '{}': {}",
-                    identifier_str, e
-                );
-                BitVMXError::InvalidCommsAddress(format!("{}: {}", identifier_str, e))
-            })?;
-            self.process_msg(identifier, msg, false)?;
+        if let Some(msg) = self.message_queue.pop_front()? {
+            self.process_msg(msg)?;
         }
         Ok(())
     }
@@ -605,7 +594,8 @@ impl BitVMX {
         for message in messages.unwrap() {
             match message {
                 ReceiveHandlerChannel::Msg(identifier, msg) => {
-                    self.process_msg(identifier, msg, true)?;
+                    let msg: QueuedMessage = QueuedMessage::new(identifier, msg);
+                    self.process_msg(msg)?;
                 }
                 ReceiveHandlerChannel::Error(e) => {
                     info!("Error receiving message {}", e);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,7 @@
 use bitcoin::{consensus::encode::FromHexError, network::ParseNetworkError};
 use bitcoin_coordinator::errors::BitcoinCoordinatorError;
 use bitcoincore_rpc::bitcoin::{key::ParsePublicKeyError, sighash::SighashTypeParseError};
-use bitvmx_broker::{
-    channel::retry_helper::RetryPolicyError, identification::errors::IdentificationError,
-    rpc::errors::BrokerError,
-};
+use bitvmx_broker::{identification::errors::IdentificationError, rpc::errors::BrokerError};
 use bitvmx_cpu_definitions::challenge::EmulatorResultError;
 use bitvmx_job_dispatcher::dispatcher_error::DispatcherError;
 use config as settings;
@@ -271,9 +268,6 @@ pub enum BitVMXError {
 
     #[error("Time error: {0}")]
     TimeError(#[from] std::time::SystemTimeError),
-
-    #[error("Retry policy error: {0}")]
-    RetryPolicyError(#[from] RetryPolicyError),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -262,6 +262,9 @@ pub enum BitVMXError {
 
     #[error("Invalid Input: {0}")]
     InvalidInput(String),
+
+    #[error("Time error: {0}")]
+    TimeError(#[from] std::time::SystemTimeError),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,10 @@
 use bitcoin::{consensus::encode::FromHexError, network::ParseNetworkError};
 use bitcoin_coordinator::errors::BitcoinCoordinatorError;
 use bitcoincore_rpc::bitcoin::{key::ParsePublicKeyError, sighash::SighashTypeParseError};
-use bitvmx_broker::{identification::errors::IdentificationError, rpc::errors::BrokerError};
+use bitvmx_broker::{
+    channel::retry_helper::RetryPolicyError, identification::errors::IdentificationError,
+    rpc::errors::BrokerError,
+};
 use bitvmx_cpu_definitions::challenge::EmulatorResultError;
 use bitvmx_job_dispatcher::dispatcher_error::DispatcherError;
 use config as settings;
@@ -268,6 +271,9 @@ pub enum BitVMXError {
 
     #[error("Time error: {0}")]
     TimeError(#[from] std::time::SystemTimeError),
+
+    #[error("Retry policy error: {0}")]
+    RetryPolicyError(#[from] RetryPolicyError),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {

--- a/src/leader_broadcast.rs
+++ b/src/leader_broadcast.rs
@@ -448,8 +448,8 @@ impl LeaderBroadcastHelper {
                 "Pending message to back: {:?} from {}",
                 original_msg.msg_type, original_msg.sender_pubkey_hash
             );
-            message_queue.push_back(
-                Identifier::new(original_msg.sender_pubkey_hash.clone(), 0).to_string(),
+            message_queue.push_new(
+                Identifier::new(original_msg.sender_pubkey_hash.clone(), 0),
                 full_message,
             )?;
         }

--- a/tests/message_queue_test.rs
+++ b/tests/message_queue_test.rs
@@ -1,4 +1,5 @@
-use bitvmx_client::message_queue::MessageQueue;
+use bitvmx_broker::identification::identifier::Identifier;
+use bitvmx_client::message_queue::{MessageQueue, QueuedMessage, MAX_MESSAGE_RETRIES};
 use std::fs;
 use std::rc::Rc;
 use storage_backend::storage::Storage;
@@ -7,7 +8,7 @@ use uuid::Uuid;
 
 #[test]
 fn test_message_queue_persistence() {
-    let temp_dir = format!("tmp_test_storage_{}", Uuid::new_v4());
+    let temp_dir = format!("/tmp/test_storage__{}", Uuid::new_v4());
     let config = StorageConfig {
         path: temp_dir.clone(),
         password: None,
@@ -20,13 +21,17 @@ fn test_message_queue_persistence() {
     // Push messages
     let msg1 = vec![1, 2, 3];
     let msg2 = vec![4, 5, 6];
-    queue.push_back("id1".to_string(), msg1.clone()).unwrap();
-    queue.push_back("id2".to_string(), msg2.clone()).unwrap();
+    let id1 = Identifier::new("id1".to_string(), 0);
+    let id2 = Identifier::new("id2".to_string(), 0);
+    let queued_message1 = QueuedMessage::new(id1.clone(), msg1.clone());
+    let queued_message2 = QueuedMessage::new(id2.clone(), msg2.clone());
+    queue.push_back(queued_message1).unwrap();
+    queue.push_back(queued_message2).unwrap();
 
     // Verify pop
-    let (id, msg) = queue.pop_front().unwrap().unwrap();
-    assert_eq!(id, "id1");
-    assert_eq!(msg, msg1);
+    let msg = queue.pop_front().unwrap().unwrap();
+    assert_eq!(msg.identifier, id1);
+    assert_eq!(msg.data, msg1);
 
     // Simulate restart (reload storage)
     drop(queue);
@@ -36,11 +41,81 @@ fn test_message_queue_persistence() {
     let queue = MessageQueue::new(storage.clone());
 
     // Verify persistence
-    let (id, msg) = queue.pop_front().unwrap().unwrap();
-    assert_eq!(id, "id2");
-    assert_eq!(msg, msg2);
+    let msg = queue.pop_front().unwrap().unwrap();
+    assert_eq!(msg.identifier, id2);
+    assert_eq!(msg.data, msg2);
 
     // Verify empty
+    assert!(queue.pop_front().unwrap().is_none());
+
+    // Cleanup
+    drop(queue);
+    drop(storage);
+    fs::remove_dir_all(temp_dir).unwrap();
+}
+
+#[test]
+fn test_queue_no_starvation() {
+    let temp_dir = format!("/tmp/test_storage_{}", Uuid::new_v4());
+    let config = StorageConfig {
+        path: temp_dir.clone(),
+        password: None,
+    };
+
+    // Create storage and queue
+    let storage = Rc::new(Storage::new(&config).unwrap());
+    let queue = MessageQueue::new(storage.clone());
+
+    // Create poison message and valid message
+    let poison_id = Identifier::new("poison".to_string(), 0);
+    let good_id = Identifier::new("good".to_string(), 0);
+    let poison_msg = vec![0xde, 0xad, 0xbe, 0xef];
+    let good_msg = vec![1, 2, 3, 4];
+    let poison = QueuedMessage::new(poison_id.clone(), poison_msg.clone());
+    let good = QueuedMessage::new(good_id.clone(), good_msg.clone());
+
+    // Push poison first, then valid message
+    queue
+        .push_new(poison.identifier.clone(), poison.data.clone())
+        .unwrap();
+    queue
+        .push_new(good.identifier.clone(), good.data.clone())
+        .unwrap();
+
+    // Simulate repeated processing failures → requeue
+    for attempt in 0..=MAX_MESSAGE_RETRIES {
+        // Process poison (should fail and be requeued)
+        let msg = queue.pop_front().unwrap().unwrap();
+        println!("Processing msg attempt {}: {:?}", attempt, msg);
+        assert_eq!(msg.identifier, poison_id);
+        assert_eq!(msg.retries, attempt);
+        queue.push_back(msg).unwrap();
+
+        // Process good (shlould fail until last attempt)
+        if attempt < MAX_MESSAGE_RETRIES {
+            let msg = queue.pop_front().unwrap().unwrap();
+            println!("Processing msg attempt {}: {:?}", attempt, msg);
+            assert_eq!(msg.identifier, good_id);
+            assert_eq!(msg.data, good_msg);
+            assert_eq!(msg.retries, attempt);
+            queue.push_back(msg).unwrap();
+        }
+    }
+
+    //Trying good message last attempt, should succeed
+    let msg = queue.pop_front().unwrap().unwrap();
+    assert_eq!(msg.identifier, good_id);
+    assert_eq!(msg.data, good_msg);
+    assert_eq!(msg.retries, MAX_MESSAGE_RETRIES);
+
+    // Queue should now be empty, poison message dropped
+    assert!(queue.pop_front().unwrap().is_none());
+
+    // Persistence check
+    drop(queue);
+    drop(storage);
+    let storage = Rc::new(Storage::new(&config).unwrap());
+    let queue = MessageQueue::new(storage.clone());
     assert!(queue.pop_front().unwrap().is_none());
 
     // Cleanup

--- a/tests/message_queue_test.rs
+++ b/tests/message_queue_test.rs
@@ -18,7 +18,7 @@ fn test_message_queue_persistence() {
 
     // Create storage and queue
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default().unwrap());
+    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default());
 
     // Push messages
     let msg1 = vec![1, 2, 3];
@@ -38,7 +38,7 @@ fn test_message_queue_persistence() {
     drop(storage);
 
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default().unwrap());
+    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default());
 
     // Verify persistence
     let msg = queue.pop_front().unwrap().unwrap();
@@ -64,7 +64,7 @@ fn test_queue_no_starvation() {
 
     // Create storage and queue
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let retry_policy = RetryPolicy::default().unwrap();
+    let retry_policy = RetryPolicy::default();
     let queue = MessageQueue::new(storage.clone(), retry_policy.clone());
 
     // Create poison message and valid message

--- a/tests/message_queue_test.rs
+++ b/tests/message_queue_test.rs
@@ -18,7 +18,7 @@ fn test_message_queue_persistence() {
 
     // Create storage and queue
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default());
+    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default().unwrap());
 
     // Push messages
     let msg1 = vec![1, 2, 3];
@@ -38,7 +38,7 @@ fn test_message_queue_persistence() {
     drop(storage);
 
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default());
+    let queue = MessageQueue::new(storage.clone(), RetryPolicy::default().unwrap());
 
     // Verify persistence
     let msg = queue.pop_front().unwrap().unwrap();
@@ -64,7 +64,7 @@ fn test_queue_no_starvation() {
 
     // Create storage and queue
     let storage = Rc::new(Storage::new(&config).unwrap());
-    let retry_policy = RetryPolicy::default();
+    let retry_policy = RetryPolicy::default().unwrap();
     let queue = MessageQueue::new(storage.clone(), retry_policy.clone());
 
     // Create poison message and valid message


### PR DESCRIPTION
This PR introduces a bounded retry mechanism for queued messages to prevent pending queue starvation and denial-of-service scenarios.

A configurable RetryPolicy and persisted RetryState were added to ensure that messages which cannot be processed are retried with backoff and eventually dropped, instead of being reinserted indefinitely at the head of the queue. This removes the infinite retry loop that allowed a single poison message to block all subsequent pending messages.

This resolves BITVMX-CLI-007 by eliminating starvation in the pending message queue and ensuring fair progress for valid messages.
Additionally, BITVMX-CLI-008 is considered resolved due to the existing per-destination rate limiting in the broker, which prevents unbounded message injection and complements the retry safeguards introduced here.

IMPORTANT: This branch should be merged with:
- [broker](https://github.com/FairgateLabs/rust-bitvmx-broker/pull/17)