### PR TITLE
Error handling improvement

### DIFF
--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -1631,10 +1631,10 @@ impl BitVMXApi for BitVMX {
             IncomingBitVMXApiMessages::GetKeyPair(id) => {
                 let collaboration = self
                     .get_collaboration(&id)?
-                    .ok_or(BitVMXError::ProgramNotFound(id))?;
+                    .ok_or_else(|| BitVMXError::ProgramNotFound(id))?;
                 let aggregated = collaboration
                     .aggregated_key
-                    .ok_or(BitVMXError::ProgramNotFound(id))?;
+                    .ok_or_else(|| BitVMXError::ProgramNotFound(id))?;
                 let pair = self
                     .program_context
                     .key_chain
@@ -1654,10 +1654,10 @@ impl BitVMXApi for BitVMX {
                 } else {
                     let collaboration = self
                         .get_collaboration(&id)?
-                        .ok_or(BitVMXError::ProgramNotFound(id))?;
+                        .ok_or_else(|| BitVMXError::ProgramNotFound(id))?;
                     let aggregated = collaboration
                         .aggregated_key
-                        .ok_or(BitVMXError::ProgramNotFound(id))?;
+                        .ok_or_else(|| BitVMXError::ProgramNotFound(id))?;
                     let pubkey = self
                         .program_context
                         .key_chain

--- a/src/collaborate.rs
+++ b/src/collaborate.rs
@@ -226,12 +226,12 @@ impl Collaboration {
             let my_position = peers
                 .iter()
                 .position(|p| p.pubkey_hash == my_pubkey_hash)
-                .ok_or(BitVMXError::InvalidParticipant(my_pubkey_hash.to_string()))?;
+                .ok_or_else(|| BitVMXError::InvalidParticipant(my_pubkey_hash.to_string()))?;
 
             public_keys
                 .get(my_position)
                 .cloned()
-                .ok_or(BitVMXError::InvalidParticipant(my_pubkey_hash.to_string()))?
+                .ok_or_else(|| BitVMXError::InvalidParticipant(my_pubkey_hash.to_string()))?
         } else {
             program_context
                 .key_chain

--- a/src/comms_helper.rs
+++ b/src/comms_helper.rs
@@ -163,7 +163,7 @@ impl CommsMessageType {
             .iter()
             .find(|(kind, _)| kind == &self)
             .map(|(_, bytes)| *bytes)
-            .ok_or(BitVMXError::InvalidMessageType)
+            .ok_or_else(|| BitVMXError::InvalidMessageType)
     }
 
     // Convert 2-byte representation to message type
@@ -173,7 +173,7 @@ impl CommsMessageType {
             .find(|(_, kind_bytes)| kind_bytes == &bytes)
             .map(|(kind, _)| *kind)
             .cloned()
-            .ok_or(BitVMXError::InvalidMessageType)
+            .ok_or_else(|| BitVMXError::InvalidMessageType)
     }
 }
 
@@ -192,7 +192,7 @@ impl Version {
             .iter()
             .find(|(v, _)| *v == version)
             .map(|(_, bytes)| *bytes)
-            .ok_or(BitVMXError::InvalidMsgVersion)
+            .ok_or_else(|| BitVMXError::InvalidMsgVersion)
     }
 
     // Convert 2-byte representation to version string
@@ -201,7 +201,7 @@ impl Version {
             .iter()
             .find(|(_, version_bytes)| version_bytes == &bytes)
             .map(|(version, _)| version.to_string())
-            .ok_or(BitVMXError::InvalidMsgVersion)
+            .ok_or_else(|| BitVMXError::InvalidMsgVersion)
     }
 }
 
@@ -311,17 +311,14 @@ pub fn deserialize_msg(
     })?;
 
     // Extract program ID and message
-    let program_id =
-        payload
-            .get("program_id")
-            .and_then(|id| id.as_str())
-            .ok_or(BitVMXError::InvalidMessage(
-                format!("Missing program ID").to_string(),
-            ))?;
+    let program_id = payload
+        .get("program_id")
+        .and_then(|id| id.as_str())
+        .ok_or_else(|| BitVMXError::InvalidMessage(format!("Missing program ID").to_string()))?;
 
-    let data = payload.get("msg").ok_or(BitVMXError::InvalidMessage(
-        format!("Missing message").to_string(),
-    ))?;
+    let data = payload
+        .get("msg")
+        .ok_or_else(|| BitVMXError::InvalidMessage(format!("Missing message").to_string()))?;
     // Convert program ID to Uuid
     let program_id = Uuid::parse_str(program_id).map_err(|_| {
         BitVMXError::InvalidMessage(format!("Invalid program ID: {:?}", program_id).to_string())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -316,6 +316,9 @@ pub enum BitVMXError {
 
     #[error("Time error: {0}")]
     TimeError(#[from] std::time::SystemTimeError),
+
+    #[error("Initialization error: {0}")]
+    InitializationError(String),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,6 +31,9 @@ pub enum BitVMXError {
     #[error("Error parsing int")]
     ParseIntError(#[from] std::num::ParseIntError),
 
+    #[error("Error parsing from script int")]
+    ScriptIntParseError(#[from] bitcoin::script::Error),
+
     #[error("Error when using KeyManager: {0}")]
     KeyManagerError(#[from] KeyManagerError),
 
@@ -175,6 +178,21 @@ pub enum BitVMXError {
     #[error("No public nonces found for aggregated public key {0} and id {1}")]
     MissingPublicNonces(String, String),
 
+    #[error("Missing nonces for program id {0}")]
+    NoncesNotFound(Uuid),
+
+    #[error("Missing partial signatures for program id {0}")]
+    PartialSignaturesNotFound(Uuid),
+
+    #[error("Storage unavailable/not found for protocol {0}")]
+    StorageUnavailable(String),
+
+    #[error("Missing block info")]
+    MissingBlockInfo,
+
+    #[error("Not found {0}")]
+    NotFound(String),
+
     #[error("Wallet error {0}")]
     WalletError(#[from] bitvmx_wallet::wallet::errors::WalletError),
 
@@ -183,6 +201,9 @@ pub enum BitVMXError {
 
     #[error("Identification error: {0}")]
     IdentificationError(#[from] IdentificationError),
+
+    #[error("IO error: {0}")]
+    IOError(#[from] std::io::Error),
 
     // Timestamp validation errors
     #[error("Message timestamp {timestamp} from peer {peer} is too far in the future (now: {now}, drift: {drift_ms}ms, max allowed: {max_drift_ms}ms)")]
@@ -262,6 +283,24 @@ pub enum BitVMXError {
 
     #[error("Invalid Input: {0}")]
     InvalidInput(String),
+
+    #[error("Merkle tree is invalid")]
+    InvalidMerkleTree,
+
+    #[error("Section not found: {0}")]
+    SectionNotFound(String),
+
+    #[error("Script not found for program id {0}")]
+    ScriptNotFound(Uuid),
+
+    #[error("TryFromSlice error: {0}")]
+    TryFromSliceError(#[from] std::array::TryFromSliceError),
+
+    #[error("Excecution error: {0}")]
+    ExecutionError(#[from] emulator::ExecutionResult),
+
+    #[error("Invalid string operation: {0}")]
+    InvalidStringOperation(String),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {
@@ -334,6 +373,9 @@ pub enum ProgramError {
 
     #[error("Program not found in storage. Program id: {0}")]
     ProgramNotFound(Uuid),
+
+    #[error("Storage unavailable")]
+    StorageUnavailable,
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,6 +28,12 @@ pub enum BitVMXError {
     #[error("Invalid parameter in configuration. {0}")]
     InvalidParameter(String),
 
+    #[error("Invalid leaf: {0}")]
+    InvalidLeaf(String),
+
+    #[error("Invalid state: {0}")]
+    InvalidState(String),
+
     #[error("Error parsing int")]
     ParseIntError(#[from] std::num::ParseIntError),
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,47 +19,130 @@ use uuid::Uuid;
 
 #[derive(Error, Debug)]
 pub enum BitVMXError {
-    #[error("Error on dispute resolution protocol setup: {0}")]
-    DisputeResolutionProtocolSetup(String),
-
+    /* =========================
+     * Configuration & Init
+     * ========================= */
     #[error("Invalid configuration")]
     ConfigurationError(#[from] ConfigError),
 
     #[error("Invalid parameter in configuration. {0}")]
     InvalidParameter(String),
 
-    #[error("Invalid leaf: {0}")]
-    InvalidLeaf(String),
+    #[error("Initialization error: {0}")]
+    InitializationError(String),
 
-    #[error("Invalid state: {0}")]
-    InvalidState(String),
+    #[error("This feature is not implemented yet {0}")]
+    NotImplemented(String),
 
+    /* =========================
+     * IO / System / Time
+     * ========================= */
+    #[error("IO error: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Time error: {0}")]
+    TimeError(#[from] std::time::SystemTimeError),
+
+    #[error("Poisoned lock error: {0}")]
+    PoisonedLockError(String),
+
+    #[error("Problem creating directory {0}: {1}")]
+    DirectoryCreationError(String, std::io::Error),
+
+    /* =========================
+     * Parsing / Serialization
+     * ========================= */
     #[error("Error parsing int")]
     ParseIntError(#[from] std::num::ParseIntError),
 
     #[error("Error parsing from script int")]
     ScriptIntParseError(#[from] bitcoin::script::Error),
 
+    #[error("Error decoding hex string: {0}")]
+    FromHexError(#[from] hex::FromHexError),
+
+    #[error("Serialization error {0}")]
+    SerdeSerializationError(#[from] serde_json::Error),
+
+    #[error("Failed to serialize or deserialize message")]
+    SerializationError,
+
+    #[error("TryFromSlice error: {0}")]
+    TryFromSliceError(#[from] std::array::TryFromSliceError),
+
+    /* =========================
+     * Cryptography / Keys / Signatures
+     * ========================= */
     #[error("Error when using KeyManager: {0}")]
     KeyManagerError(#[from] KeyManagerError),
 
     #[error("KeyChain error: {0}")]
     KeyChainError(String),
 
-    #[error("Error when using Bitcoin client: {0}")]
-    BitcoinError(#[from] BitcoinClientError),
-
     #[error("Error when creating unspendable key: {0}")]
     UnspendableKeyError(#[from] UnspendableKeyError),
 
-    #[error("Error when creating protocol: {0}")]
-    ProtocolBuilderError(#[from] ProtocolBuilderError),
+    #[error("Failed in MuSig2 signer {0}")]
+    MuSig2SignerError(#[from] Musig2SignerError),
 
-    #[error("Error decoding hex string: {0}")]
-    FromHexError(#[from] hex::FromHexError),
+    #[error("Failed to process a Winternitz signature: {0}")]
+    WinternitzError(#[from] WinternitzError),
+
+    #[error("Invalid RSA signature from peer {peer} for message type {msg_type:?} in program {program_id}")]
+    InvalidSignature {
+        peer: String,
+        msg_type: String,
+        program_id: String,
+    },
+
+    #[error("Missing verification key for sender {peer}. Known keys: {known_count}")]
+    MissingVerificationKey { peer: String, known_count: usize },
+
+    #[error("Failed to extract verification key from VerificationKey message: {reason}")]
+    VerificationKeyExtractionError { reason: String },
+
+    #[error("Failed to reconstruct message for signature verification: {reason}")]
+    MessageReconstructionError { reason: String },
+
+    #[error("Verification key announcement hash mismatch for peer {peer}: expected {expected}, got {got}")]
+    VerificationKeyHashMismatch {
+        peer: String,
+        expected: String,
+        got: String,
+    },
+
+    #[error("Verification key fingerprint mismatch for peer {peer}:  computed {computed}")]
+    VerificationKeyFingerprintMismatch { peer: String, computed: String },
+
+    /* =========================
+     * Wallet / Storage
+     * ========================= */
+    #[error("Wallet error {0}")]
+    WalletError(#[from] bitvmx_wallet::wallet::errors::WalletError),
 
     #[error("Error when creating the storagge: {0}")]
     StorageError(#[from] StorageError),
+
+    #[error("Storage unavailable/not found for protocol {0}")]
+    StorageUnavailable(String),
+
+    /* =========================
+     * Program / Protocol
+     * ========================= */
+    #[error("Error when creating protocol: {0}")]
+    ProtocolBuilderError(#[from] ProtocolBuilderError),
+
+    #[error("Dispute resolution protocol setup error: {0}")]
+    DisputeResolutionProtocolSetup(String),
+
+    #[error("ProgramDefinition Error {0}")]
+    ProgramDefinitionError(#[from] ProgramDefinitionError),
+
+    #[error("Program already exists")]
+    ProgramAlreadyExists(Uuid),
+
+    #[error("Program {0} is not ready to run. Please install it first.")]
+    ProgramNotReady(Uuid),
 
     #[error("Cannot find program with id {0}")]
     ProgramNotFound(Uuid),
@@ -70,26 +153,50 @@ pub enum BitVMXError {
     #[error("A program error has occurred: {0}")]
     ProgramError(#[from] ProgramError),
 
-    #[error("Failed to process a Winternitz signature: {0}")]
-    WinternitzError(#[from] WinternitzError),
+    /* =========================
+     * Execution / Emulator / ZKP
+     * ========================= */
+    #[error("Emulator Error {0}")]
+    EmulatorError(#[from] EmulatorError),
 
-    #[error("Program {0} is not ready to run. Please install it first.")]
-    ProgramNotReady(Uuid),
+    #[error("Emulator Result Error {0}")]
+    EmulatorResultError(#[from] EmulatorResultError),
 
-    #[error("Cannot find the variable {0}.{1}")]
-    VariableNotFound(Uuid, String),
+    #[error("Execution error: {0}")]
+    ExecutionError(#[from] emulator::ExecutionResult),
 
-    #[error("Invalid variable type: {0}")]
-    InvalidVariableType(String),
+    #[error("Inconsistent data retrieved of ZKP execution result from job {0}")]
+    InconsistentZKPData(Uuid),
 
+    /* =========================
+     * Witness / Merkle / Scripts
+     * ========================= */
     #[error("Invalid witness type")]
     InvalidWitnessType,
 
     #[error("Invalid witness: {0:?}")]
     InvalidWitness(Witness),
 
+    #[error("Invalid merkle tree")]
+    InvalidMerkleTree,
+
+    #[error("Script not found for program id {0}")]
+    ScriptNotFound(Uuid),
+
+    #[error("Error creating script {0}")]
+    ScriptError(#[from] ScriptError),
+
+    #[error("Invalid leaf: {0}")]
+    InvalidLeaf(String),
+
+    /* =========================
+     * Messaging / Dispatcher / Comms
+     * ========================= */
     #[error("Job type error {0}")]
     DispatcherError(#[from] DispatcherError),
+
+    #[error("Job Dispatcher {0} is not responding")]
+    JobDispatcherNotResponding(String),
 
     #[error("Failed to use Comms layer")]
     CommsCommunicationError,
@@ -97,17 +204,11 @@ pub enum BitVMXError {
     #[error("Invalid Comms address: {0}")]
     InvalidCommsAddress(String),
 
-    #[error("Keys not found in program {0}")]
-    KeysNotFound(Uuid),
-
-    #[error("Failed to use Bitcoin Coordinator: {0}")]
-    BitcoinCoordinatorError(#[from] BitcoinCoordinatorError),
-
     #[error("Broker channel error")]
     BrokerError(#[from] BrokerError),
 
-    #[error("Serialization error {0}")]
-    SerdeSerializationError(#[from] serde_json::Error),
+    #[error("Client error")]
+    ClientError(#[from] ClientError),
 
     #[error("Invalid parser version")]
     InvalidMsgVersion,
@@ -115,112 +216,21 @@ pub enum BitVMXError {
     #[error("Invalid message type")]
     InvalidMessageType,
 
-    #[error("Failed to serialize or deserialize message")]
-    SerializationError,
-
     #[error("Invalid receive message format")]
     InvalidMessageFormat,
 
     #[error("Invalid message: {0}")]
     InvalidMessage(String),
 
-    #[error("Invalid transaction name {0}")]
-    InvalidTransactionName(String),
-
-    #[error("Invalid transaction status {0}")]
-    InvalidTransactionStatus(String),
-
     #[error("Failed to process message")]
     MessageProcessingError,
-
-    #[error("Failed in MuSig2 signer {0}")]
-    MuSig2SignerError(#[from] Musig2SignerError),
-
-    #[error("Program already exists")]
-    ProgramAlreadyExists(Uuid),
-
-    #[error("Error creating script {0}")]
-    ScriptError(#[from] ScriptError),
-
-    #[error("Client error")]
-    ClientError(#[from] ClientError),
-
-    #[error("This feature is not implemented yet {0}")]
-    NotImplemented(String),
-
-    #[error("Emulator Error {0}")]
-    EmulatorError(#[from] EmulatorError),
-
-    #[error("Emulator Result Error {0}")]
-    EmulatorResultError(#[from] EmulatorResultError),
-
-    #[error("ProgramDefinition Error {0}")]
-    ProgramDefinitionError(#[from] ProgramDefinitionError),
-
-    #[error("Instrucion {0} not found")]
-    InstructionNotFound(String),
-
-    #[error("Challenge {0} not found")]
-    ChallengeNotFound(String),
-
-    #[error("Challenge with idx {0} not found")]
-    ChallengeIdxNotFound(u32),
-
-    #[error("Rom data {0} not found")]
-    RomDataNotFound(u32),
-
-    #[error("Insufficient amount to send the transaction")]
-    InsufficientAmount,
-
-    #[error("Transaction not found in block")]
-    TransactionNotFoundInBlock,
-
-    #[error("Inconsistent data retrieved of ZKP execution result from job {0}")]
-    InconsistentZKPData(Uuid),
-
-    #[error("Problem creating directory {0}: {1}")]
-    DirectoryCreationError(String, std::io::Error),
-
-    #[error("Peer id {0} not found in the list of participants")]
-    InvalidParticipant(String),
-
-    #[error("No signatures found for aggregated public key {0} and id {1}")]
-    MissingPartialSignatures(String, String),
-
-    #[error("No public nonces found for aggregated public key {0} and id {1}")]
-    MissingPublicNonces(String, String),
-
-    #[error("Missing parameter: {0}")]
-    MissingParameter(String),
-
-    #[error("Missing nonces for program id {0}")]
-    NoncesNotFound(Uuid),
-
-    #[error("Missing partial signatures for program id {0}")]
-    PartialSignaturesNotFound(Uuid),
-
-    #[error("Storage unavailable/not found for protocol {0}")]
-    StorageUnavailable(String),
-
-    #[error("Missing block info")]
-    MissingBlockInfo,
-
-    #[error("Not found {0}")]
-    NotFound(String),
-
-    #[error("Wallet error {0}")]
-    WalletError(#[from] bitvmx_wallet::wallet::errors::WalletError),
-
-    #[error("Invalid List: {0}")]
-    InvalidList(String),
 
     #[error("Identification error: {0}")]
     IdentificationError(#[from] IdentificationError),
 
-    #[error("IO error: {0}")]
-    IOError(#[from] std::io::Error),
-
-    // Timestamp validation errors
+    /* =========================
+     * Timestamp / Replay
+     * ========================= */
     #[error("Message timestamp {timestamp} from peer {peer} is too far in the future (now: {now}, drift: {drift_ms}ms, max allowed: {max_drift_ms}ms)")]
     TimestampTooFarInFuture {
         peer: String,
@@ -246,37 +256,26 @@ pub enum BitVMXError {
         last_timestamp: i64,
     },
 
-    // Signature and key verification errors
-    #[error("Invalid RSA signature from peer {peer} for message type {msg_type:?} in program {program_id}")]
-    InvalidSignature {
-        peer: String,
-        msg_type: String,
-        program_id: String,
-    },
+    /* =========================
+     * Bitcoin / Transactions
+     * ========================= */
+    #[error("Error when using Bitcoin client: {0}")]
+    BitcoinError(#[from] BitcoinClientError),
 
-    #[error("Verification key not found for sender {peer}. Known keys: {known_count}")]
-    MissingVerificationKey { peer: String, known_count: usize },
+    #[error("Failed to use Bitcoin Coordinator: {0}")]
+    BitcoinCoordinatorError(#[from] BitcoinCoordinatorError),
 
-    #[error("Failed to extract verification key from VerificationKey message: {reason}")]
-    VerificationKeyExtractionError { reason: String },
+    #[error("Invalid transaction name {0}")]
+    InvalidTransactionName(String),
 
-    #[error("Failed to reconstruct message for signature verification: {reason}")]
-    MessageReconstructionError { reason: String },
+    #[error("Invalid transaction status {0}")]
+    InvalidTransactionStatus(String),
 
-    #[error(
-        "Verification key announcement hash mismatch for peer {peer}: expected {expected}, got {got}"
-    )]
-    VerificationKeyHashMismatch {
-        peer: String,
-        expected: String,
-        got: String,
-    },
+    #[error("Transaction not found in block")]
+    TransactionNotFoundInBlock,
 
-    #[error("Verification key fingerprint mismatch for peer {peer}:  computed {computed}")]
-    VerificationKeyFingerprintMismatch { peer: String, computed: String },
-
-    #[error("Job Dispatcher {0} is not responding")]
-    JobDispatcherNotResponding(String),
+    #[error("Insufficient amount to send the transaction")]
+    InsufficientAmount,
 
     #[error("Missing input signature for transaction {tx_name}, input index {input_index}, script index {script_index:?}")]
     MissingInputSignature {
@@ -293,38 +292,74 @@ pub enum BitVMXError {
         source: ProtocolBuilderError,
     },
 
-    #[error("Poisoned lock error: {0}")]
-    PoisonedLockError(String),
+    /* =========================
+     * Validation / State / Logic
+     * ========================= */
+    #[error("Invalid state: {0}")]
+    InvalidState(String),
 
-    #[error("Invalid Input: {0}")]
-    InvalidInput(String),
-
-    #[error("Invalid Input(s): {0:?}")]
-    InvalidInputs(Vec<(usize, String)>),
-
-    #[error("Merkle tree is invalid")]
-    InvalidMerkleTree,
-
-    #[error("Section not found: {0}")]
-    SectionNotFound(String),
-
-    #[error("Script not found for program id {0}")]
-    ScriptNotFound(Uuid),
-
-    #[error("TryFromSlice error: {0}")]
-    TryFromSliceError(#[from] std::array::TryFromSliceError),
-
-    #[error("Excecution error: {0}")]
-    ExecutionError(#[from] emulator::ExecutionResult),
+    #[error("Invalid variable type: {0}")]
+    InvalidVariableType(String),
 
     #[error("Invalid string operation: {0}")]
     InvalidStringOperation(String),
 
-    #[error("Time error: {0}")]
-    TimeError(#[from] std::time::SystemTimeError),
+    #[error("Peer id {0} not found in the list of participants")]
+    InvalidParticipant(String),
 
-    #[error("Initialization error: {0}")]
-    InitializationError(String),
+    #[error("Invalid input: {0}")]
+    InvalidInput(String),
+
+    #[error("Invalid inputs: {0:?}")]
+    InvalidInputs(Vec<(usize, String)>),
+
+    #[error("Invalid list: {0}")]
+    InvalidList(String),
+
+    /* =========================
+     * Missing / Not Found
+     * ========================= */
+    #[error("Variable {0}.{1} not found")]
+    VariableNotFound(Uuid, String),
+
+    #[error("Keys not found in program {0}")]
+    KeysNotFound(Uuid),
+
+    #[error("Missing block info")]
+    MissingBlockInfo,
+
+    #[error("Missing parameter: {0}")]
+    MissingParameter(String),
+
+    #[error("Missing nonces for program id {0}")]
+    NoncesNotFound(Uuid),
+
+    #[error("Missing partial signatures for program id {0}")]
+    PartialSignaturesNotFound(Uuid),
+
+    #[error("No signatures found for aggregated public key {0} and id {1}")]
+    MissingPartialSignatures(String, String),
+
+    #[error("No public nonces found for aggregated public key {0} and id {1}")]
+    MissingPublicNonces(String, String),
+
+    #[error("Section not found: {0}")]
+    SectionNotFound(String),
+
+    #[error("Challenge {0} not found")]
+    ChallengeNotFound(String),
+
+    #[error("Challenge with idx {0} not found")]
+    ChallengeIdxNotFound(u32),
+
+    #[error("Rom data {0} not found")]
+    RomDataNotFound(u32),
+
+    #[error("Instruction {0} not found")]
+    InstructionNotFound(String),
+
+    #[error("Not found {0}")]
+    NotFound(String),
 }
 
 impl<T> From<PoisonError<T>> for BitVMXError {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,4 +1,4 @@
-use bitcoin::{consensus::encode::FromHexError, network::ParseNetworkError};
+use bitcoin::{consensus::encode::FromHexError, network::ParseNetworkError, Witness};
 use bitcoin_coordinator::errors::BitcoinCoordinatorError;
 use bitcoincore_rpc::bitcoin::{key::ParsePublicKeyError, sighash::SighashTypeParseError};
 use bitvmx_broker::{identification::errors::IdentificationError, rpc::errors::BrokerError};
@@ -79,6 +79,9 @@ pub enum BitVMXError {
     #[error("Invalid witness type")]
     InvalidWitnessType,
 
+    #[error("Invalid witness: {0:?}")]
+    InvalidWitness(Witness),
+
     #[error("Job type error {0}")]
     DispatcherError(#[from] DispatcherError),
 
@@ -117,6 +120,9 @@ pub enum BitVMXError {
 
     #[error("Invalid transaction name {0}")]
     InvalidTransactionName(String),
+
+    #[error("Invalid transaction status {0}")]
+    InvalidTransactionStatus(String),
 
     #[error("Failed to process message")]
     MessageProcessingError,
@@ -286,6 +292,9 @@ pub enum BitVMXError {
 
     #[error("Invalid Input: {0}")]
     InvalidInput(String),
+
+    #[error("Invalid Input(s): {0:?}")]
+    InvalidInputs(Vec<(usize, String)>),
 
     #[error("Merkle tree is invalid")]
     InvalidMerkleTree,

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -303,9 +303,7 @@ impl KeyChain {
         Ok(self
             .rsa_public_key
             .clone()
-            .ok_or(BitVMXError::InvalidMessage(
-                "No RSA public key found".to_string(),
-            ))?)
+            .ok_or_else(|| BitVMXError::InvalidMessage("No RSA public key found".to_string()))?)
     }
 }
 

--- a/src/keychain.rs
+++ b/src/keychain.rs
@@ -59,7 +59,7 @@ impl KeyChain {
                 )
             )));
         }
-        let pem_file = std::fs::read_to_string(path).unwrap();
+        let pem_file = std::fs::read_to_string(path)?;
         let rsa_pubkey_pem = key_manager.import_rsa_private_key(&pem_file)?;
 
         Ok(Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ fn init_bitvmx(opn: &str, fresh: bool) -> Result<BitVMX> {
         clear_db(&config.comms.storage_path);
 
         if config.bitcoin.network == Network::Regtest {
-            Wallet::clear_db(&config.wallet).unwrap();
+            Wallet::clear_db(&config.wallet)?;
         }
     }
 

--- a/src/program/participant.rs
+++ b/src/program/participant.rs
@@ -137,8 +137,8 @@ impl ParticipantKeys {
             .ok_or(BitVMXError::InvalidMessageFormat)?)
     }
 
-    pub fn speedup(&self) -> &PublicKey {
-        self.get_public("speedup").unwrap()
+    pub fn speedup(&self) -> Result<&PublicKey, BitVMXError> {
+        self.get_public("speedup")
     }
 }
 

--- a/src/program/participant.rs
+++ b/src/program/participant.rs
@@ -123,18 +123,18 @@ impl ParticipantKeys {
         Ok(self
             .mapping
             .get(name)
-            .ok_or(BitVMXError::InvalidMessageFormat)?
+            .ok_or_else(|| BitVMXError::InvalidMessageFormat)?
             .winternitz()
-            .ok_or(BitVMXError::InvalidMessageFormat)?)
+            .ok_or_else(|| BitVMXError::InvalidMessageFormat)?)
     }
 
     pub fn get_public(&self, name: &str) -> Result<&PublicKey, BitVMXError> {
         Ok(self
             .mapping
             .get(name)
-            .ok_or(BitVMXError::InvalidMessageFormat)?
+            .ok_or_else(|| BitVMXError::InvalidMessageFormat)?
             .public()
-            .ok_or(BitVMXError::InvalidMessageFormat)?)
+            .ok_or_else(|| BitVMXError::InvalidMessageFormat)?)
     }
 
     pub fn speedup(&self) -> Result<&PublicKey, BitVMXError> {

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -154,11 +154,15 @@ impl Program {
         let comms_address =
             CommsAddress::new(program_context.comms.get_address(), my_pubkey_hash.clone());
 
-        //FIX EXCPECT WITH PROPER ERROR (invalid message as I'm not in the list)
         let my_idx = peers
             .iter()
             .position(|peer| peer.pubkey_hash == comms_address.pubkey_hash)
-            .expect("Peer not found in the list");
+            .ok_or_else(|| {
+                BitVMXError::InvalidMessage(format!(
+                    "Peer with pubkey hash {} not found in the list",
+                    comms_address.pubkey_hash
+                ))
+            })?;
 
         info!("my_pos: {}", my_idx);
         info!("Leader pos: {}", leader);

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -216,13 +216,13 @@ impl Program {
         for agg_name in &self.participants[self.my_idx]
             .keys
             .as_ref()
-            .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+            .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
             .aggregated
         {
             let agg_key = self.participants[self.my_idx]
                 .keys
                 .as_ref()
-                .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+                .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
                 .get_public(agg_name)
                 .map_err(|_| BitVMXError::InvalidMessageFormat)?;
 
@@ -237,7 +237,7 @@ impl Program {
                 let other_key = other
                     .keys
                     .as_ref()
-                    .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+                    .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
                     .get_public(agg_name)
                     .map_err(|_| BitVMXError::InvalidMessageFormat)?;
                 aggregated_pub_keys.push(*other_key);
@@ -263,7 +263,7 @@ impl Program {
         self.participants[self.my_idx]
             .keys
             .as_mut()
-            .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+            .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
             .computed_aggregated = result.clone();
         Ok(result)
     }
@@ -281,7 +281,7 @@ impl Program {
             .map(|p| {
                 p.keys
                     .as_ref()
-                    .ok_or(BitVMXError::KeysNotFound(self.program_id))
+                    .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))
                     .map(|k| k.clone())
             })
             .collect::<Result<Vec<_>, _>>()?;
@@ -359,7 +359,7 @@ impl Program {
                     other
                         .keys
                         .clone()
-                        .ok_or(BitVMXError::KeysNotFound(self.program_id))?,
+                        .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?,
                 ));
             }
             keys
@@ -372,7 +372,7 @@ impl Program {
                 self.participants[self.my_idx]
                     .keys
                     .clone()
-                    .ok_or(BitVMXError::KeysNotFound(self.program_id))?,
+                    .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?,
             )]
         };
         self.request_helper(program_context, keys, CommsMessageType::Keys)?;
@@ -408,7 +408,7 @@ impl Program {
             parse_keys(data).map_err(|_| BitVMXError::InvalidMessageFormat)?
         {
             let other_pos = get_other_index_by_pubkey_hash(&pubkey_hash, &self.participants)
-                .ok_or(BitVMXError::InvalidParticipant(pubkey_hash))?;
+                .ok_or_else(|| BitVMXError::InvalidParticipant(pubkey_hash))?;
             self.participants[other_pos].keys = Some(keys);
         }
 
@@ -438,7 +438,7 @@ impl Program {
         for aggregated in self.participants[self.my_idx]
             .keys
             .as_ref()
-            .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+            .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
             .computed_aggregated
             .values()
         {
@@ -504,7 +504,7 @@ impl Program {
 
         for (pubkey_hash, particpant_nonces) in nonces_msg {
             let other_pos = get_other_index_by_pubkey_hash(&pubkey_hash, &self.participants)
-                .ok_or(BitVMXError::InvalidParticipant(pubkey_hash))?;
+                .ok_or_else(|| BitVMXError::InvalidParticipant(pubkey_hash))?;
             debug!("{}. Got nonces for pos: {}", self.my_idx, other_pos);
             self.participants[other_pos].nonces = Some(particpant_nonces);
         }
@@ -521,7 +521,7 @@ impl Program {
                     for (aggregated, participant_pub_key, nonces) in participant
                         .nonces
                         .as_ref()
-                        .ok_or(BitVMXError::NoncesNotFound(self.program_id))?
+                        .ok_or_else(|| BitVMXError::NoncesNotFound(self.program_id))?
                     {
                         debug!(
                             "will get nonces for: {} {:?} {:?} {:?} ",
@@ -569,7 +569,7 @@ impl Program {
         for aggregated in self.participants[self.my_idx]
             .keys
             .as_ref()
-            .ok_or(BitVMXError::KeysNotFound(self.program_id))?
+            .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))?
             .computed_aggregated
             .values()
         {
@@ -607,7 +607,7 @@ impl Program {
                     other
                         .partial
                         .clone()
-                        .ok_or(BitVMXError::PartialSignaturesNotFound(self.program_id))?,
+                        .ok_or_else(|| BitVMXError::PartialSignaturesNotFound(self.program_id))?,
                 ));
             }
         }
@@ -643,7 +643,7 @@ impl Program {
         let partial_msg = parse_signatures(data).map_err(|_| BitVMXError::InvalidMessageFormat)?;
         for (pubkey_hash, particpant_partials) in partial_msg {
             let other_pos = get_other_index_by_pubkey_hash(&pubkey_hash, &self.participants)
-                .ok_or(BitVMXError::InvalidParticipant(pubkey_hash))?;
+                .ok_or_else(|| BitVMXError::InvalidParticipant(pubkey_hash))?;
             debug!("{}. Got partials for pos: {}", self.my_idx, other_pos);
             self.participants[other_pos].partial = Some(particpant_partials);
         }
@@ -660,7 +660,7 @@ impl Program {
                     for (aggregated, other_pub_key, signatures) in participant
                         .partial
                         .as_ref()
-                        .ok_or(BitVMXError::PartialSignaturesNotFound(self.program_id))?
+                        .ok_or_else(|| BitVMXError::PartialSignaturesNotFound(self.program_id))?
                     {
                         debug!(
                             "Program {}: agg: {}, other: {} Received signatures: {:?}",
@@ -895,7 +895,7 @@ impl Program {
             .map(|p| {
                 p.keys
                     .as_ref()
-                    .ok_or(BitVMXError::KeysNotFound(self.program_id))
+                    .ok_or_else(|| BitVMXError::KeysNotFound(self.program_id))
             })
             .collect::<Result<Vec<_>, _>>()?;
 
@@ -952,7 +952,7 @@ impl Program {
         let retries = self
             .storage
             .as_ref()
-            .ok_or(BitVMXError::StorageUnavailable(self.program_id.to_string()))?
+            .ok_or_else(|| BitVMXError::StorageUnavailable(self.program_id.to_string()))?
             .get(Self::get_key(key.clone()))?
             .unwrap_or(ProgramRequestInfo::default())
             .retries
@@ -965,7 +965,7 @@ impl Program {
 
         self.storage
             .as_ref()
-            .ok_or(BitVMXError::StorageUnavailable(self.program_id.to_string()))?
+            .ok_or_else(|| BitVMXError::StorageUnavailable(self.program_id.to_string()))?
             .set(Self::get_key(key), last_request, None)?;
 
         Ok(())
@@ -976,7 +976,7 @@ impl Program {
         let last_request: ProgramRequestInfo = self
             .storage
             .as_ref()
-            .ok_or(BitVMXError::StorageUnavailable(self.program_id.to_string()))?
+            .ok_or_else(|| BitVMXError::StorageUnavailable(self.program_id.to_string()))?
             .get(Self::get_key(key.clone()))?
             .unwrap_or(ProgramRequestInfo::default());
 

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -107,7 +107,8 @@ impl Program {
             .get(Self::get_key(StoreKey::ProgramState(*program_id)))?
             .unwrap_or_default();
 
-        let mut program: Program = program.ok_or(ProgramError::ProgramNotFound(*program_id))?;
+        let mut program: Program =
+            program.ok_or_else(|| ProgramError::ProgramNotFound(*program_id))?;
 
         program.state = program_state;
         program.storage = Some(storage.clone());

--- a/src/program/protocols/cardinal/lock_config.rs
+++ b/src/program/protocols/cardinal/lock_config.rs
@@ -52,24 +52,21 @@ impl LockProtocolConfiguration {
     }
 
     pub fn new_from_globals(id: Uuid, globals: &Globals) -> Result<Self, BitVMXError> {
-        let operators_aggregated_pub = globals
-            .get_var(&id, "operators_aggregated_pub")?
-            .unwrap()
-            .pubkey()?;
-        let ops_agg_happy_path = globals
-            .get_var(&id, "operators_aggregated_happy_path")?
-            .unwrap()
-            .pubkey()?;
-        let unspendable = globals.get_var(&id, "unspendable")?.unwrap().pubkey()?;
-        let user_pubkey = globals.get_var(&id, "user_pubkey")?.unwrap().pubkey()?;
-        let secret = globals.get_var(&id, "secret")?.unwrap().secret()?;
-        let ordinal_utxo = globals.get_var(&id, "ordinal_utxo")?.unwrap().utxo()?;
-        let protocol_utxo = globals.get_var(&id, "protocol_utxo")?.unwrap().utxo()?;
-        let timelock_blocks = globals.get_var(&id, "timelock_blocks")?.unwrap().number()? as u16;
-        let eol_timelock_duration = globals
-            .get_var(&id, EOL_TIMELOCK_DURATION)?
-            .unwrap()
-            .number()? as u16;
+        let get = |key: &str| {
+            globals
+                .get_var(&id, key)?
+                .ok_or(BitVMXError::VariableNotFound(id, key.to_string()))
+        };
+
+        let operators_aggregated_pub = get("operators_aggregated_pub")?.pubkey()?;
+        let ops_agg_happy_path = get("operators_aggregated_happy_path")?.pubkey()?;
+        let unspendable = get("unspendable")?.pubkey()?;
+        let user_pubkey = get("user_pubkey")?.pubkey()?;
+        let secret = get("secret")?.secret()?;
+        let ordinal_utxo = get("ordinal_utxo")?.utxo()?;
+        let protocol_utxo = get("protocol_utxo")?.utxo()?;
+        let timelock_blocks = get("timelock_blocks")?.number()? as u16;
+        let eol_timelock_duration = get(EOL_TIMELOCK_DURATION)?.number()? as u16;
 
         Ok(Self::new(
             id,

--- a/src/program/protocols/cardinal/lock_config.rs
+++ b/src/program/protocols/cardinal/lock_config.rs
@@ -52,11 +52,7 @@ impl LockProtocolConfiguration {
     }
 
     pub fn new_from_globals(id: Uuid, globals: &Globals) -> Result<Self, BitVMXError> {
-        let get = |key: &str| {
-            globals
-                .get_var(&id, key)?
-                .ok_or(BitVMXError::VariableNotFound(id, key.to_string()))
-        };
+        let get = |key: &str| globals.get_var_or_err(&id, key);
 
         let operators_aggregated_pub = get("operators_aggregated_pub")?.pubkey()?;
         let ops_agg_happy_path = get("operators_aggregated_happy_path")?.pubkey()?;

--- a/src/program/protocols/claim.rs
+++ b/src/program/protocols/claim.rs
@@ -184,11 +184,11 @@ impl ClaimGate {
             None,
         )?;
 
-        if exclusive_success_vout.is_some() {
+        if let Some(exclusive_success_vout) = exclusive_success_vout {
             protocol.add_connection(
                 &format!("{}_EXCLUSIVE_{}", from, &success),
                 &from,
-                OutputSpec::Index(exclusive_success_vout.unwrap()),
+                OutputSpec::Index(exclusive_success_vout),
                 &success,
                 InputSpec::Auto(SighashType::taproot_all(), SpendMode::Script { leaf: 0 }),
                 None,

--- a/src/program/protocols/dispute/challenge.rs
+++ b/src/program/protocols/dispute/challenge.rs
@@ -310,9 +310,11 @@ pub fn challenge_scripts(
                     "input" => {
                         let base_addr = program
                             .find_section_by_name(&program_definitions.input_section_name)
-                            .ok_or(BitVMXError::SectionNotFound(
-                                program_definitions.input_section_name.clone(),
-                            ))?
+                            .ok_or_else(|| {
+                                BitVMXError::SectionNotFound(
+                                    program_definitions.input_section_name.clone(),
+                                )
+                            })?
                             .start;
 
                         let (inputs, _) = generate_input_owner_list(&program_definitions)?;
@@ -377,18 +379,22 @@ pub fn challenge_scripts(
                                     let previous_protocol = context
                                         .globals
                                         .get_var(id, &program_input_prev_protocol(idx as u32))?
-                                        .ok_or(BitVMXError::VariableNotFound(
-                                            *id,
-                                            program_input_prev_protocol(idx as u32),
-                                        ))?
+                                        .ok_or_else(|| {
+                                            BitVMXError::VariableNotFound(
+                                                *id,
+                                                program_input_prev_protocol(idx as u32),
+                                            )
+                                        })?
                                         .uuid()?;
                                     let previous_prefix = context
                                         .globals
                                         .get_var(id, &program_input_prev_prefix(idx as u32))?
-                                        .ok_or(BitVMXError::VariableNotFound(
-                                            *id,
-                                            program_input_prev_prefix(idx as u32),
-                                        ))?
+                                        .ok_or_else(|| {
+                                            BitVMXError::VariableNotFound(
+                                                *id,
+                                                program_input_prev_prefix(idx as u32),
+                                            )
+                                        })?
                                         .string()?;
 
                                     for j in 0..*words {
@@ -402,10 +408,12 @@ pub fn challenge_scripts(
                                         let pubkey = context
                                             .globals
                                             .get_var(&previous_protocol, &key)?
-                                            .ok_or(BitVMXError::VariableNotFound(
-                                                previous_protocol,
-                                                key.clone(),
-                                            ))?
+                                            .ok_or_else(|| {
+                                                BitVMXError::VariableNotFound(
+                                                    previous_protocol,
+                                                    key.clone(),
+                                                )
+                                            })?
                                             .wots_pubkey()?;
                                         //we copy the var so the prover is able to decode it when it sees the challenge tx
                                         if role == ParticipantRole::Prover {
@@ -443,7 +451,7 @@ pub fn challenge_scripts(
                                         let address = base_addr + j * 4;
                                         let mut scripts = vec![alternate_reverse
                                             .as_ref()
-                                            .ok_or(BitVMXError::ScriptNotFound(*id))?
+                                            .ok_or_else(|| BitVMXError::ScriptNotFound(*id))?
                                             .clone()];
                                         stack = StackTracker::new();
 
@@ -451,7 +459,9 @@ pub fn challenge_scripts(
                                         let value = context
                                             .globals
                                             .get_var(id, &key)?
-                                            .ok_or(BitVMXError::VariableNotFound(*id, key.clone()))?
+                                            .ok_or_else(|| {
+                                                BitVMXError::VariableNotFound(*id, key.clone())
+                                            })?
                                             .input()?;
 
                                         let value =
@@ -860,9 +870,9 @@ pub fn get_challenge_leaf(
 
             let base_addr = program
                 .find_section_by_name(&program_definitions.input_section_name)
-                .ok_or(BitVMXError::SectionNotFound(
-                    program_definitions.input_section_name.clone(),
-                ))?
+                .ok_or_else(|| {
+                    BitVMXError::SectionNotFound(program_definitions.input_section_name.clone())
+                })?
                 .start;
             dynamic_offset = (address - base_addr) / 4;
         }
@@ -901,7 +911,7 @@ pub fn get_challenge_leaf(
 
             let base_addr = program
                 .find_section_by_name(".rodata")
-                .ok_or(BitVMXError::SectionNotFound(".rodata".to_string()))?
+                .ok_or_else(|| BitVMXError::SectionNotFound(".rodata".to_string()))?
                 .start;
             dynamic_offset = address - base_addr;
         }
@@ -1116,7 +1126,7 @@ pub fn get_challenge_leaf(
     let leaf_start = context
         .globals
         .get_var(id, &leaf_start_var)?
-        .ok_or(BitVMXError::VariableNotFound(*id, leaf_start_var.clone()))?
+        .ok_or_else(|| BitVMXError::VariableNotFound(*id, leaf_start_var.clone()))?
         .number()? as u32;
 
     info!(

--- a/src/program/protocols/dispute/challenge.rs
+++ b/src/program/protocols/dispute/challenge.rs
@@ -1109,8 +1109,7 @@ pub fn get_challenge_leaf(
     let leaf_start_var = format!("challenge_leaf_start_{}", name);
     let leaf_start = context
         .globals
-        .get_var(id, &leaf_start_var)?
-        .ok_or_else(|| BitVMXError::VariableNotFound(*id, leaf_start_var.clone()))?
+        .get_var_or_err(id, &leaf_start_var)?
         .number()? as u32;
 
     info!(

--- a/src/program/protocols/dispute/challenge.rs
+++ b/src/program/protocols/dispute/challenge.rs
@@ -263,12 +263,10 @@ pub fn challenge_scripts(
                             .iter()
                             .map(|(var_name, _)| {
                                 let idx = if var_name.starts_with("prover") { 0 } else { 1 };
-                                let key = keys[idx].get_winternitz(var_name).unwrap_or_else(|_| {
-                                    panic!("Missing winternitz key for var_name: {}", var_name)
-                                });
-                                (var_name, key)
+                                let key = keys[idx].get_winternitz(var_name)?;
+                                Ok((var_name, key))
                             })
-                            .collect::<Vec<_>>(),
+                            .collect::<Result<Vec<_>, BitVMXError>>()?,
                         None,
                     )
                 };
@@ -644,7 +642,11 @@ pub fn challenge_scripts(
                                     );
                                 stack.custom(verification_script, 1, false, 0, "");
                             }
-                            _ => panic!("Unknown challenge name: {}", challenge_name),
+                            _ => {
+                                return Err(BitVMXError::ChallengeNotFound(
+                                    challenge_name.to_string(),
+                                ))
+                            }
                         };
                         scripts.push(stack.get_script());
                         let winternitz_check = scripts::verify_winternitz_signatures_aux(
@@ -671,12 +673,10 @@ pub fn challenge_scripts(
                     .iter()
                     .map(|(var_name, _)| {
                         let idx = if var_name.starts_with("prover") { 0 } else { 1 };
-                        let key = keys[idx].get_winternitz(var_name).unwrap_or_else(|_| {
-                            panic!("Missing winternitz key for var_name: {}", var_name)
-                        });
-                        (var_name, key)
+                        let key = keys[idx].get_winternitz(var_name)?;
+                        Ok((var_name, key))
                     })
-                    .collect::<Vec<_>>();
+                    .collect::<Result<Vec<_>, BitVMXError>>()?;
 
                 //TODO: This is a workaround to reverse the order of the stack
                 let mut stack = StackTracker::new();
@@ -769,7 +769,11 @@ pub fn challenge_scripts(
                             "equivocation_hash" => {
                                 equivocation_hash_challenge(&mut stack);
                             }
-                            _ => panic!("Unknown challenge name: {}", challenge_name),
+                            _ => {
+                                return Err(BitVMXError::ChallengeNotFound(
+                                    challenge_name.to_string(),
+                                ))
+                            }
                         }
                         scripts.push(stack.get_script());
                         let winternitz_check = scripts::verify_winternitz_signatures_aux(

--- a/src/program/protocols/dispute/challenge.rs
+++ b/src/program/protocols/dispute/challenge.rs
@@ -376,23 +376,14 @@ pub fn challenge_scripts(
                                 ProgramInputType::ProverPrev(words, offset) => {
                                     let previous_protocol = context
                                         .globals
-                                        .get_var(id, &program_input_prev_protocol(idx as u32))?
-                                        .ok_or_else(|| {
-                                            BitVMXError::VariableNotFound(
-                                                *id,
-                                                program_input_prev_protocol(idx as u32),
-                                            )
-                                        })?
+                                        .get_var_or_err(
+                                            id,
+                                            &program_input_prev_protocol(idx as u32),
+                                        )?
                                         .uuid()?;
                                     let previous_prefix = context
                                         .globals
-                                        .get_var(id, &program_input_prev_prefix(idx as u32))?
-                                        .ok_or_else(|| {
-                                            BitVMXError::VariableNotFound(
-                                                *id,
-                                                program_input_prev_prefix(idx as u32),
-                                            )
-                                        })?
+                                        .get_var_or_err(id, &program_input_prev_prefix(idx as u32))?
                                         .string()?;
 
                                     for j in 0..*words {
@@ -405,13 +396,7 @@ pub fn challenge_scripts(
                                         );
                                         let pubkey = context
                                             .globals
-                                            .get_var(&previous_protocol, &key)?
-                                            .ok_or_else(|| {
-                                                BitVMXError::VariableNotFound(
-                                                    previous_protocol,
-                                                    key.clone(),
-                                                )
-                                            })?
+                                            .get_var_or_err(&previous_protocol, &key)?
                                             .wots_pubkey()?;
                                         //we copy the var so the prover is able to decode it when it sees the challenge tx
                                         if role == ParticipantRole::Prover {
@@ -454,13 +439,8 @@ pub fn challenge_scripts(
                                         stack = StackTracker::new();
 
                                         let key = program_input_word(idx as u32, j);
-                                        let value = context
-                                            .globals
-                                            .get_var(id, &key)?
-                                            .ok_or_else(|| {
-                                                BitVMXError::VariableNotFound(*id, key.clone())
-                                            })?
-                                            .input()?;
+                                        let value =
+                                            context.globals.get_var_or_err(id, &key)?.input()?;
 
                                         let value =
                                             u32::from_be_bytes(value.as_slice().try_into()?);

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -64,11 +64,7 @@ impl DisputeConfiguration {
 
     // The structure is serialized as a whole. If there is a performance hit it could be serialized in parts.
     pub fn load(id: &Uuid, globals: &Globals) -> Result<Self, BitVMXError> {
-        let dispute_configuration = globals
-            .get_var(id, Self::NAME)?
-            .ok_or_else(|| BitVMXError::VariableNotFound(*id, Self::NAME.to_string()))?
-            .string()?;
-
+        let dispute_configuration = globals.get_var_or_err(id, Self::NAME)?.string()?;
         Ok(serde_json::from_str(&dispute_configuration)?)
     }
 

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -64,7 +64,10 @@ impl DisputeConfiguration {
 
     // The structure is serialized as a whole. If there is a performance hit it could be serialized in parts.
     pub fn load(id: &Uuid, globals: &Globals) -> Result<Self, BitVMXError> {
-        let dispute_configuration = globals.get_var(id, Self::NAME)?.unwrap().string()?;
+        let dispute_configuration = globals
+            .get_var(id, Self::NAME)?
+            .ok_or(BitVMXError::VariableNotFound(*id, Self::NAME.to_string()))?
+            .string()?;
 
         Ok(serde_json::from_str(&dispute_configuration)?)
     }

--- a/src/program/protocols/dispute/config.rs
+++ b/src/program/protocols/dispute/config.rs
@@ -66,7 +66,7 @@ impl DisputeConfiguration {
     pub fn load(id: &Uuid, globals: &Globals) -> Result<Self, BitVMXError> {
         let dispute_configuration = globals
             .get_var(id, Self::NAME)?
-            .ok_or(BitVMXError::VariableNotFound(*id, Self::NAME.to_string()))?
+            .ok_or_else(|| BitVMXError::VariableNotFound(*id, Self::NAME.to_string()))?
             .string()?;
 
         Ok(serde_json::from_str(&dispute_configuration)?)

--- a/src/program/protocols/dispute/execution.rs
+++ b/src/program/protocols/dispute/execution.rs
@@ -69,14 +69,7 @@ pub fn execution_result(
             let save_round = context
                 .globals
                 .get_var(id, "current_round2")? // 2nd n-ary search
-                .unwrap_or(
-                    context
-                        .globals
-                        .get_var(id, "current_round")?
-                        .ok_or_else(|| {
-                            BitVMXError::VariableNotFound(*id, "current_round".to_string())
-                        })?,
-                ) // 1st n-ary search
+                .unwrap_or(context.globals.get_var_or_err(id, "current_round")?) // 1st n-ary search
                 .number()? as u8;
 
             let is_second_nary_search = context.globals.get_var(id, "current_round2")?.is_some();
@@ -133,14 +126,7 @@ pub fn execution_result(
             let save_round = context
                 .globals
                 .get_var(id, "current_round2")? // 2nd n-ary search
-                .unwrap_or(
-                    context
-                        .globals
-                        .get_var(id, "current_round")?
-                        .ok_or_else(|| {
-                            BitVMXError::VariableNotFound(*id, "current_round".to_string())
-                        })?,
-                ) // 1st n-ary search
+                .unwrap_or(context.globals.get_var_or_err(id, "current_round")?) // 1st n-ary search
                 .number()? as u8;
 
             if save_round != *round {

--- a/src/program/protocols/dispute/execution.rs
+++ b/src/program/protocols/dispute/execution.rs
@@ -69,9 +69,14 @@ pub fn execution_result(
             let save_round = context
                 .globals
                 .get_var(id, "current_round2")? // 2nd n-ary search
-                .unwrap_or(context.globals.get_var(id, "current_round")?.ok_or(
-                    BitVMXError::VariableNotFound(*id, "current_round".to_string()),
-                )?) // 1st n-ary search
+                .unwrap_or(
+                    context
+                        .globals
+                        .get_var(id, "current_round")?
+                        .ok_or_else(|| {
+                            BitVMXError::VariableNotFound(*id, "current_round".to_string())
+                        })?,
+                ) // 1st n-ary search
                 .number()? as u8;
 
             let is_second_nary_search = context.globals.get_var(id, "current_round2")?.is_some();
@@ -128,9 +133,14 @@ pub fn execution_result(
             let save_round = context
                 .globals
                 .get_var(id, "current_round2")? // 2nd n-ary search
-                .unwrap_or(context.globals.get_var(id, "current_round")?.ok_or(
-                    BitVMXError::VariableNotFound(*id, "current_round".to_string()),
-                )?) // 1st n-ary search
+                .unwrap_or(
+                    context
+                        .globals
+                        .get_var(id, "current_round")?
+                        .ok_or_else(|| {
+                            BitVMXError::VariableNotFound(*id, "current_round".to_string())
+                        })?,
+                ) // 1st n-ary search
                 .number()? as u8;
 
             if save_round != *round {

--- a/src/program/protocols/dispute/execution.rs
+++ b/src/program/protocols/dispute/execution.rs
@@ -82,7 +82,12 @@ pub fn execution_result(
                 ("NARY_PROVER", "prover_hash") // 1st n-ary search
             };
 
-            assert_eq!(save_round, *round);
+            if save_round != *round {
+                return Err(BitVMXError::InvalidState(format!(
+                    "Saved round {} does not match the expected round {}",
+                    save_round, round
+                )));
+            }
             for (i, h) in hashes.iter().enumerate() {
                 set_input_hex(
                     id,
@@ -128,7 +133,12 @@ pub fn execution_result(
                 )?) // 1st n-ary search
                 .number()? as u8;
 
-            assert_eq!(save_round, *round);
+            if save_round != *round {
+                return Err(BitVMXError::InvalidState(format!(
+                    "Saved round {} does not match the expected round {}",
+                    save_round, round
+                )));
+            }
 
             let (nary_verifier, selection_bits) =
                 if context.globals.get_var(id, "current_round2")?.is_some() {

--- a/src/program/protocols/dispute/input_handler.rs
+++ b/src/program/protocols/dispute/input_handler.rs
@@ -114,18 +114,19 @@ pub fn get_required_keys(
                 let full_input = program_context
                     .globals
                     .get_var(id, &program_input(idx as u32, None))?
-                    .ok_or(BitVMXError::VariableNotFound(
-                        *id,
-                        program_input(idx as u32, None),
-                    ))?
+                    .ok_or_else(|| {
+                        BitVMXError::VariableNotFound(*id, program_input(idx as u32, None))
+                    })?
                     .input()?;
 
                 for i in 0..*words {
                     let partial_input = full_input
                         .get((i * 4) as usize..((i + 1) * 4) as usize)
-                        .ok_or(BitVMXError::DisputeResolutionProtocolSetup(
-                            "Input size is not valid".to_string(),
-                        ))?;
+                        .ok_or_else(|| {
+                            BitVMXError::DisputeResolutionProtocolSetup(
+                                "Input size is not valid".to_string(),
+                            )
+                        })?;
                     program_context.globals.set_var(
                         id,
                         &program_input_word(idx as u32, i + offset),
@@ -184,7 +185,7 @@ pub fn split_input(
     let full_input = program_context
         .globals
         .get_var(id, &program_input(idx, None))?
-        .ok_or(BitVMXError::VariableNotFound(*id, program_input(idx, None)))?
+        .ok_or_else(|| BitVMXError::VariableNotFound(*id, program_input(idx, None)))?
         .input()?;
     let words = input_txs_sizes[idx as usize];
     let owner = input_txs[idx as usize].as_str();
@@ -198,9 +199,9 @@ pub fn split_input(
     for i in 0..words {
         let partial_input = full_input
             .get((i * 4) as usize..((i + 1) * 4) as usize)
-            .ok_or(BitVMXError::DisputeResolutionProtocolSetup(
-                "Input size is not valid".to_string(),
-            ))?;
+            .ok_or_else(|| {
+                BitVMXError::DisputeResolutionProtocolSetup("Input size is not valid".to_string())
+            })?;
         program_context.globals.set_var(
             id,
             &program_input(offset + i, Some(&role)),
@@ -218,7 +219,7 @@ pub fn get_txs_configuration(
         program_context
             .globals
             .get_var(id, key)?
-            .ok_or(BitVMXError::VariableNotFound(*id, key.to_string()))
+            .ok_or_else(|| BitVMXError::VariableNotFound(*id, key.to_string()))
     };
 
     let input_txs = get("input_txs")?.vec_string()?;
@@ -256,7 +257,7 @@ pub fn unify_witnesses(
         let input = program_context
             .witness
             .get_witness(id, &key)?
-            .ok_or(BitVMXError::VariableNotFound(*id, key))?
+            .ok_or_else(|| BitVMXError::VariableNotFound(*id, key))?
             .winternitz()?
             .message_bytes();
         info!("Unifying input for tx {}: {}", idx, hex::encode(&input));
@@ -284,18 +285,16 @@ pub fn unify_inputs(
             let previous_protocol = program_context
                 .globals
                 .get_var(id, &program_input_prev_protocol(idx as u32))?
-                .ok_or(BitVMXError::VariableNotFound(
-                    *id,
-                    program_input_prev_protocol(idx as u32),
-                ))?
+                .ok_or_else(|| {
+                    BitVMXError::VariableNotFound(*id, program_input_prev_protocol(idx as u32))
+                })?
                 .uuid()?;
             let previous_prefix = program_context
                 .globals
                 .get_var(id, &program_input_prev_prefix(idx as u32))?
-                .ok_or(BitVMXError::VariableNotFound(
-                    *id,
-                    program_input_prev_prefix(idx as u32),
-                ))?
+                .ok_or_else(|| {
+                    BitVMXError::VariableNotFound(*id, program_input_prev_prefix(idx as u32))
+                })?
                 .string()?;
 
             info!(
@@ -312,10 +311,7 @@ pub fn unify_inputs(
                 let signature = &program_context
                     .witness
                     .get_witness(&previous_protocol, &key)?
-                    .ok_or(BitVMXError::VariableNotFound(
-                        previous_protocol,
-                        key.clone(),
-                    ))?
+                    .ok_or_else(|| BitVMXError::VariableNotFound(previous_protocol, key.clone()))?
                     .winternitz()?;
                 //copy the witness to the current program so the when needed it can be used to sign txs
                 program_context
@@ -331,7 +327,7 @@ pub fn unify_inputs(
             &program_context
                 .globals
                 .get_var(id, key)?
-                .ok_or(BitVMXError::VariableNotFound(*id, key.clone()))?
+                .ok_or_else(|| BitVMXError::VariableNotFound(*id, key.clone()))?
                 .input()?,
         );
         info!(

--- a/src/program/protocols/dispute/input_handler.rs
+++ b/src/program/protocols/dispute/input_handler.rs
@@ -246,8 +246,7 @@ pub fn unify_witnesses(
         let key = program_input(offset + i, Some(&owner));
         let input = program_context
             .witness
-            .get_witness(id, &key)?
-            .ok_or_else(|| BitVMXError::VariableNotFound(*id, key))?
+            .get_witness_or_err(id, &key)?
             .winternitz()?
             .message_bytes();
         info!("Unifying input for tx {}: {}", idx, hex::encode(&input));
@@ -294,8 +293,7 @@ pub fn unify_inputs(
                 );
                 let signature = &program_context
                     .witness
-                    .get_witness(&previous_protocol, &key)?
-                    .ok_or_else(|| BitVMXError::VariableNotFound(previous_protocol, key.clone()))?
+                    .get_witness_or_err(&previous_protocol, &key)?
                     .winternitz()?;
                 //copy the witness to the current program so the when needed it can be used to sign txs
                 program_context

--- a/src/program/protocols/dispute/input_handler.rs
+++ b/src/program/protocols/dispute/input_handler.rs
@@ -34,7 +34,6 @@ pub fn generate_input_owner_list(
                 "Input size cannot be zero and need to be a multiple of 4".to_string(),
             ));
         }
-        assert!(input.size % 4 == 0, "Input size must be a multiple of 4");
         let words = (input.size / 4) as u32;
 
         match input.owner.as_str() {

--- a/src/program/protocols/dispute/input_handler.rs
+++ b/src/program/protocols/dispute/input_handler.rs
@@ -114,13 +114,18 @@ pub fn get_required_keys(
                 let full_input = program_context
                     .globals
                     .get_var(id, &program_input(idx as u32, None))?
-                    .unwrap()
+                    .ok_or(BitVMXError::VariableNotFound(
+                        *id,
+                        program_input(idx as u32, None),
+                    ))?
                     .input()?;
 
                 for i in 0..*words {
                     let partial_input = full_input
                         .get((i * 4) as usize..((i + 1) * 4) as usize)
-                        .unwrap();
+                        .ok_or(BitVMXError::DisputeResolutionProtocolSetup(
+                            "Input size is not valid".to_string(),
+                        ))?;
                     program_context.globals.set_var(
                         id,
                         &program_input_word(idx as u32, i + offset),
@@ -179,7 +184,7 @@ pub fn split_input(
     let full_input = program_context
         .globals
         .get_var(id, &program_input(idx, None))?
-        .unwrap()
+        .ok_or(BitVMXError::VariableNotFound(*id, program_input(idx, None)))?
         .input()?;
     let words = input_txs_sizes[idx as usize];
     let owner = input_txs[idx as usize].as_str();
@@ -193,7 +198,9 @@ pub fn split_input(
     for i in 0..words {
         let partial_input = full_input
             .get((i * 4) as usize..((i + 1) * 4) as usize)
-            .unwrap();
+            .ok_or(BitVMXError::DisputeResolutionProtocolSetup(
+                "Input size is not valid".to_string(),
+            ))?;
         program_context.globals.set_var(
             id,
             &program_input(offset + i, Some(&role)),
@@ -207,26 +214,17 @@ pub fn get_txs_configuration(
     id: &Uuid,
     program_context: &ProgramContext,
 ) -> Result<(Vec<String>, Vec<u32>, Vec<u32>, u32), BitVMXError> {
-    let input_txs = program_context
-        .globals
-        .get_var(id, "input_txs")?
-        .unwrap()
-        .vec_string()?;
-    let input_txs_sizes = program_context
-        .globals
-        .get_var(id, "input_txs_sizes")?
-        .unwrap()
-        .vec_number()?;
-    let input_txs_offsets = program_context
-        .globals
-        .get_var(id, "input_txs_offsets")?
-        .unwrap()
-        .vec_number()?;
-    let last_tx_id = program_context
-        .globals
-        .get_var(id, "last_tx_id")?
-        .unwrap()
-        .number()?;
+    let get = |key: &str| {
+        program_context
+            .globals
+            .get_var(id, key)?
+            .ok_or(BitVMXError::VariableNotFound(*id, key.to_string()))
+    };
+
+    let input_txs = get("input_txs")?.vec_string()?;
+    let input_txs_sizes = get("input_txs_sizes")?.vec_number()?;
+    let input_txs_offsets = get("input_txs_offsets")?.vec_number()?;
+    let last_tx_id = get("last_tx_id")?.number()?;
 
     if input_txs.len() != input_txs_sizes.len() || input_txs.len() != input_txs_offsets.len() {
         return Err(BitVMXError::DisputeResolutionProtocolSetup(
@@ -258,7 +256,7 @@ pub fn unify_witnesses(
         let input = program_context
             .witness
             .get_witness(id, &key)?
-            .unwrap()
+            .ok_or(BitVMXError::VariableNotFound(*id, key))?
             .winternitz()?
             .message_bytes();
         info!("Unifying input for tx {}: {}", idx, hex::encode(&input));
@@ -286,12 +284,18 @@ pub fn unify_inputs(
             let previous_protocol = program_context
                 .globals
                 .get_var(id, &program_input_prev_protocol(idx as u32))?
-                .unwrap()
+                .ok_or(BitVMXError::VariableNotFound(
+                    *id,
+                    program_input_prev_protocol(idx as u32),
+                ))?
                 .uuid()?;
             let previous_prefix = program_context
                 .globals
                 .get_var(id, &program_input_prev_prefix(idx as u32))?
-                .unwrap()
+                .ok_or(BitVMXError::VariableNotFound(
+                    *id,
+                    program_input_prev_prefix(idx as u32),
+                ))?
                 .string()?;
 
             info!(
@@ -308,7 +312,10 @@ pub fn unify_inputs(
                 let signature = &program_context
                     .witness
                     .get_witness(&previous_protocol, &key)?
-                    .unwrap()
+                    .ok_or(BitVMXError::VariableNotFound(
+                        previous_protocol,
+                        key.clone(),
+                    ))?
                     .winternitz()?;
                 //copy the witness to the current program so the when needed it can be used to sign txs
                 program_context
@@ -320,7 +327,13 @@ pub fn unify_inputs(
         }
 
         let key = &program_input(idx as u32, None);
-        full_input.extend_from_slice(&program_context.globals.get_var(id, key)?.unwrap().input()?);
+        full_input.extend_from_slice(
+            &program_context
+                .globals
+                .get_var(id, key)?
+                .ok_or(BitVMXError::VariableNotFound(*id, key.clone()))?
+                .input()?,
+        );
         info!(
             "Unifying input from tx {}: {}",
             key,

--- a/src/program/protocols/dispute/mod.rs
+++ b/src/program/protocols/dispute/mod.rs
@@ -428,7 +428,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
         if name.starts_with(INPUT_TX) {
             let idx = name
                 .strip_prefix(INPUT_TX)
-                .ok_or(BitVMXError::InvalidStringOperation(name.to_string()))?
+                .ok_or_else(|| BitVMXError::InvalidStringOperation(name.to_string()))?
                 .parse::<u32>()?;
             split_input(&self.ctx.id, idx, context)?;
             let (tx, speedup) =
@@ -488,7 +488,7 @@ impl ProtocolHandler for DisputeResolutionProtocol {
         let verifier_speedup_pub = keys[1].get_public("speedup")?;
         let aggregated = computed_aggregated
             .get("aggregated_1")
-            .ok_or(BitVMXError::NotFound("aggregated_1".to_string()))?;
+            .ok_or_else(|| BitVMXError::NotFound("aggregated_1".to_string()))?;
         let (agg_or_prover, agg_or_verifier, sign_mode) =
             (prover_speedup_pub, verifier_speedup_pub, SignMode::Single);
 
@@ -497,11 +497,11 @@ impl ProtocolHandler for DisputeResolutionProtocol {
 
         let mut protocol = self.load_or_create_protocol();
 
-        let mut amount = utxo.2.ok_or(BitVMXError::MissingParameter(
+        let mut amount = utxo.2.ok_or_else(|| BitVMXError::MissingParameter(
             "UTXO amount is required".to_string(),
         ))?;
         info!("Protocol amount: {}", amount);
-        let output_type = utxo.3.ok_or(BitVMXError::MissingParameter(
+        let output_type = utxo.3.ok_or_else(|| BitVMXError::MissingParameter(
             "UTXO output type is required".to_string(),
         ))?;
 
@@ -1066,7 +1066,7 @@ impl DisputeResolutionProtocol {
             None,
         )?;
 
-        let output_type = utxo_action.3.as_ref().ok_or(BitVMXError::MissingParameter(
+        let output_type = utxo_action.3.as_ref().ok_or_else(|| BitVMXError::MissingParameter(
             "UTXO output type is required".to_string(),
         ))?;
         protocol.add_external_transaction(&external_action(role, action_number))?;

--- a/src/program/protocols/dispute/tx_news.rs
+++ b/src/program/protocols/dispute/tx_news.rs
@@ -42,7 +42,7 @@ fn dispatch_timeout_tx(
     let params = program_context
         .globals
         .get_var(&drp.ctx.id, name)?
-        .unwrap()
+        .ok_or_else(|| BitVMXError::VariableNotFound(drp.ctx.id, name.to_string()))?
         .vec_number()?;
     let input = params[0];
     let leaf = params[1];
@@ -170,9 +170,10 @@ impl TimeoutDispatchTable {
     pub fn new(rules: Vec<TimeoutDispatchRule>) -> Self {
         Self { rules }
     }
-    pub fn new_predefined(rounds: u8, inputs: Vec<(usize, &String)>) -> Self {
-        assert_ne!(rounds, 0);
-        assert_ne!(inputs.len(), 0); // Inputs should be at least 1
+    pub fn new_predefined(rounds: u8, inputs: Vec<(usize, &String)>) -> Result<Self, BitVMXError> {
+        if rounds == 0 || inputs.is_empty() {
+            return Err(Self::invalid_inputs(&inputs));
+        }
 
         let last_tx_first_nary = &format!("NARY_VERIFIER_{}", rounds);
         let last_tx_second_nary = &format!("NARY2_VERIFIER_{}", rounds);
@@ -180,7 +181,10 @@ impl TimeoutDispatchTable {
 
         let mut table = TimeoutDispatchTable::new(vec![]);
 
-        let &(first_index, first_owner) = inputs.first().unwrap();
+        let &(first_index, first_owner) = inputs
+            .first()
+            .ok_or_else(|| Self::invalid_inputs(&inputs))?;
+
         if first_owner == "verifier" {
             table.add_prover_without_vout(
                 &input_tx_name(first_index as u32),
@@ -211,7 +215,8 @@ impl TimeoutDispatchTable {
                 role,
             );
         }
-        let &(last_index, last_owner) = inputs.last().unwrap();
+        let &(last_index, last_owner) =
+            inputs.last().ok_or_else(|| Self::invalid_inputs(&inputs))?;
         assert!(last_owner.starts_with("prover"));
 
         table.add_classic_to(&input_tx_name(last_index as u32), PRE_COMMITMENT, Prover);
@@ -225,7 +230,7 @@ impl TimeoutDispatchTable {
         table.add_nary_search_table("NARY2", 2, rounds);
         table.add_classic_to(&last_tx_second_nary, GET_HASHES_AND_STEP, Verifier);
         table.add_classic_to(GET_HASHES_AND_STEP, CHALLENGE_READ, Prover);
-        table
+        Ok(table)
     }
 
     fn add_nary_search_table(&mut self, nary_type: &str, start_round: u8, total_rounds: u8) {
@@ -377,6 +382,10 @@ impl TimeoutDispatchTable {
         }
 
         info!("\n{}", output);
+    }
+
+    fn invalid_inputs(inputs: &[(usize, &String)]) -> BitVMXError {
+        BitVMXError::InvalidInputs(inputs.iter().map(|(i, s)| (*i, (*s).clone())).collect())
     }
 }
 
@@ -619,7 +628,15 @@ pub fn handle_tx_news(
     program_context: &ProgramContext,
 ) -> Result<(), BitVMXError> {
     let name = drp.get_transaction_name_by_id(tx_id)?;
-    let current_height = tx_status.block_info.as_ref().unwrap().height;
+    let current_height = tx_status
+        .block_info
+        .as_ref()
+        .ok_or_else(|| {
+            BitVMXError::InvalidTransactionStatus(
+                "TransactionStatus missing block_info".to_string(),
+            )
+        })?
+        .height;
     info!(
         "Program {}: Transaction name: {}  id: {}:{:?} has been seen on-chain {}. Height: {}",
         drp.ctx.id,
@@ -641,7 +658,7 @@ pub fn handle_tx_news(
     let inputs = program_context
         .globals
         .get_var(&drp.ctx.id, "input_txs")?
-        .unwrap()
+        .ok_or_else(|| BitVMXError::VariableNotFound(drp.ctx.id, "input_txs".to_string()))?
         .vec_string()?;
 
     let inputs = inputs
@@ -650,7 +667,7 @@ pub fn handle_tx_news(
         .filter(|(_, owner)| owner.as_str() != "skip" && owner.as_str() != "prover_prev")
         .collect();
 
-    let timeout_table = TimeoutDispatchTable::new_predefined(rounds, inputs);
+    let timeout_table = TimeoutDispatchTable::new_predefined(rounds, inputs)?;
     // timeout_table.visualize();
 
     cancel_timeout(drp, &name, vout, program_context, &timeout_table)?;
@@ -681,40 +698,6 @@ pub fn handle_tx_news(
 
     let fail_force_config = config.fail_force_config.unwrap_or_default();
 
-    if vout.is_some() {
-        let transaction = &tx_status.tx;
-        let input_index = drp.find_prevout(tx_id, vout.unwrap(), transaction)?;
-        let witness = transaction.input[input_index as usize].witness.clone();
-
-        let leaf = read_scriptint(witness.third_to_last().unwrap()).unwrap() as u32;
-
-        let params = program_context
-            .globals
-            .get_var(&drp.ctx.id, &timeout_input_tx(&name))?
-            .ok_or(BitVMXError::VariableNotFound(
-                drp.ctx.id,
-                timeout_input_tx(&name),
-            ))?
-            .vec_number()?;
-
-        let timeout_leaf = params[1];
-
-        if leaf == timeout_leaf {
-            let role = timeout_table
-                .iter()
-                .find_map(|(_, _, role, timeout_type, _)| match timeout_type {
-                    TimeoutType::TimeoutInput(timeout_name) if timeout_name == &name => {
-                        Some(role.to_string())
-                    }
-                    _ => None,
-                })
-                .unwrap_or("Unknown role".to_string());
-
-            warn!("{role} consumed timeout input for {name}");
-            return Ok(());
-        }
-    }
-
     if let Some(auto_dispatch_input) = config.auto_dispatch_input {
         if name == START_CH && drp.role() == ParticipantRole::Prover {
             let (tx, speedup) = drp.get_transaction_by_name(
@@ -736,54 +719,214 @@ pub fn handle_tx_news(
         }
     }
 
-    if name.starts_with(INPUT_TX) && vout.is_some() {
-        let idx = name.strip_prefix(INPUT_TX).unwrap().parse::<u32>()?;
+    match vout {
+        Some(vout) => {
+            let transaction = &tx_status.tx;
+            let input_index = drp.find_prevout(tx_id, vout, transaction)?;
+            let witness = transaction.input[input_index as usize].witness.clone();
 
-        let (input_txs, _input_txs_sizes, _input_txs_offsets, last_tx_id) =
-            get_txs_configuration(&drp.ctx.id, program_context)?;
+            let leaf = read_scriptint(
+                witness
+                    .third_to_last()
+                    .ok_or_else(|| BitVMXError::InvalidWitness(witness.clone()))?,
+            )? as u32;
 
-        let owner = input_txs[idx as usize].as_str();
+            let params = program_context
+                .globals
+                .get_var(&drp.ctx.id, &timeout_input_tx(&name))?
+                .ok_or_else(|| BitVMXError::VariableNotFound(drp.ctx.id, timeout_input_tx(&name)))?
+                .vec_number()?;
 
-        // decode the witness
-        if owner != drp.role().to_string() {
-            drp.decode_witness_from_speedup(
-                tx_id,
-                vout.unwrap(),
-                &name,
-                program_context,
-                &tx_status.tx,
-                None,
-            )?;
-            unify_witnesses(&drp.ctx.id, program_context, idx as usize)?;
-        }
+            let timeout_leaf = params[1];
 
-        if drp.role() == ParticipantRole::Prover && idx != last_tx_id as u32 {
-            let (def, _program_definition) = drp.get_program_definition(program_context)?;
-            let full_input = unify_inputs(&drp.ctx.id, program_context, &def)?;
-            for (i, input_chunk) in full_input.chunks(4).enumerate() {
-                // It is assumed that each input chunk is 4 bytes
-                set_input(
+            if leaf == timeout_leaf {
+                let role = timeout_table
+                    .iter()
+                    .find_map(|(_, _, role, timeout_type, _)| match timeout_type {
+                        TimeoutType::TimeoutInput(timeout_name) if timeout_name == &name => {
+                            Some(role.to_string())
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or("Unknown role".to_string());
+
+                warn!("{role} consumed timeout input for {name}");
+                return Ok(());
+            }
+
+            if name.starts_with(INPUT_TX) {
+                let idx = name
+                    .strip_prefix(INPUT_TX)
+                    .ok_or_else(|| BitVMXError::InvalidStringOperation(name.clone()))?
+                    .parse::<u32>()?;
+
+                let (input_txs, _input_txs_sizes, _input_txs_offsets, last_tx_id) =
+                    get_txs_configuration(&drp.ctx.id, program_context)?;
+
+                let owner = input_txs[idx as usize].as_str();
+
+                // decode the witness
+                if owner != drp.role().to_string() {
+                    drp.decode_witness_from_speedup(
+                        tx_id,
+                        vout,
+                        &name,
+                        program_context,
+                        &tx_status.tx,
+                        None,
+                    )?;
+                    unify_witnesses(&drp.ctx.id, program_context, idx as usize)?;
+                }
+
+                if drp.role() == ParticipantRole::Prover && idx != last_tx_id as u32 {
+                    let (def, _program_definition) = drp.get_program_definition(program_context)?;
+                    let full_input = unify_inputs(&drp.ctx.id, program_context, &def)?;
+                    for (i, input_chunk) in full_input.chunks(4).enumerate() {
+                        // It is assumed that each input chunk is 4 bytes
+                        set_input(
+                            &drp.ctx.id,
+                            program_context,
+                            &program_input(i as u32, Some(&ParticipantRole::Prover)),
+                            input_chunk.to_vec(),
+                        )?;
+                    }
+                    let (tx, sp) = drp.get_tx_with_speedup_data(
+                        program_context,
+                        &input_tx_name(idx + 1),
+                        0,
+                        0,
+                        true,
+                    )?;
+                    program_context.bitcoin_coordinator.dispatch(
+                        tx,
+                        Some(sp),
+                        Context::ProgramId(drp.ctx.id).to_string()?,
+                        None,
+                        None, // Receive news on every confirmation.
+                    )?;
+                }
+                if idx == last_tx_id as u32 {
+                    //if it's the last input
+                    if drp.role() == ParticipantRole::Verifier {
+                        let (tx, sp) = drp.get_tx_with_speedup_data(
+                            program_context,
+                            PRE_COMMITMENT,
+                            0,
+                            0,
+                            true,
+                        )?;
+                        program_context.bitcoin_coordinator.dispatch(
+                            tx,
+                            Some(sp),
+                            Context::ProgramId(drp.ctx.id).to_string()?,
+                            None,
+                            None, // Receive news on every confirmation.
+                        )?;
+                    } else {
+                        //Prover
+                        let (def, _program_definition) =
+                            drp.get_program_definition(program_context)?;
+                        let full_input = unify_inputs(&drp.ctx.id, program_context, &def)?;
+                        program_context.globals.set_var(
+                            &drp.ctx.id,
+                            "full_input",
+                            VariableTypes::Input(full_input.clone()),
+                        )?;
+                    }
+                }
+            }
+
+            if name == PRE_COMMITMENT && drp.role() == ParticipantRole::Prover {
+                let (_def, program_definition) = drp.get_program_definition(program_context)?;
+                let execution_path = drp.get_execution_path()?;
+                let full_input = program_context
+                    .globals
+                    .get_var(&drp.ctx.id, "full_input")?
+                    .ok_or_else(|| {
+                        BitVMXError::VariableNotFound(drp.ctx.id, "full_input".to_string())
+                    })?
+                    .input()?;
+                let msg = serde_json::to_string(&DispatcherJob {
+                    job_id: drp.ctx.id.to_string(),
+                    job_type: EmulatorJobType::ProverExecute(
+                        program_definition,
+                        full_input,
+                        execution_path.clone(),
+                        format!("{}/{}", execution_path, "execution.json").to_string(),
+                        fail_force_config.main.fail_config_prover.clone(),
+                    ),
+                })?;
+                program_context
+                    .broker_channel
+                    .send(&program_context.components_config.emulator, msg)?;
+            }
+
+            if name == COMMITMENT && drp.role() == ParticipantRole::Verifier {
+                drp.decode_witness_from_speedup(
+                    tx_id,
+                    vout,
+                    &name,
+                    program_context,
+                    &tx_status.tx,
+                    None,
+                )?;
+
+                let execution_path = drp.get_execution_path()?;
+
+                let (def, program_definition) = drp.get_program_definition(program_context)?;
+                let input_program = unify_inputs(&drp.ctx.id, program_context, &def)?;
+
+                let last_hash = program_context
+                    .witness
+                    .get_witness(&drp.ctx.id, "prover_last_hash")?
+                    .ok_or_else(|| {
+                        BitVMXError::VariableNotFound(drp.ctx.id, "prover_last_hash".to_string())
+                    })?
+                    .winternitz()?
+                    .message_bytes();
+
+                let last_step = program_context
+                    .witness
+                    .get_witness(&drp.ctx.id, "prover_last_step")?
+                    .ok_or_else(|| {
+                        BitVMXError::VariableNotFound(drp.ctx.id, "prover_last_step".to_string())
+                    })?
+                    .winternitz()?
+                    .message_bytes();
+                let last_step_len = last_step.len();
+                let last_step = u64::from_be_bytes(last_step.try_into().map_err(|_| {
+                    BitVMXError::InvalidParameter(format!(
+                        "Invalid last_step length: {}",
+                        last_step_len
+                    ))
+                })?);
+                set_input_u64(
                     &drp.ctx.id,
                     program_context,
-                    &program_input(i as u32, Some(&ParticipantRole::Prover)),
-                    input_chunk.to_vec(),
+                    "verifier_last_step_tk",
+                    last_step,
                 )?;
-            }
-            let (tx, sp) =
-                drp.get_tx_with_speedup_data(program_context, &input_tx_name(idx + 1), 0, 0, true)?;
-            program_context.bitcoin_coordinator.dispatch(
-                tx,
-                Some(sp),
-                Context::ProgramId(drp.ctx.id).to_string()?,
-                None,
-                None, // Receive news on every confirmation.
-            )?;
-        }
-        if idx == last_tx_id as u32 {
-            //if it's the last input
-            if drp.role() == ParticipantRole::Verifier {
+
+                let msg = serde_json::to_string(&DispatcherJob {
+                    job_id: drp.ctx.id.to_string(),
+                    job_type: EmulatorJobType::VerifierCheckExecution(
+                        program_definition,
+                        input_program,
+                        execution_path.clone(),
+                        last_step,
+                        hex::encode(last_hash),
+                        format!("{}/{}", execution_path, "execution.json").to_string(),
+                        fail_force_config.main.force_condition.clone(),
+                        fail_force_config.main.fail_config_verifier.clone(),
+                    ),
+                })?;
+
+                program_context
+                    .broker_channel
+                    .send(&program_context.components_config.emulator, msg)?;
+
                 let (tx, sp) =
-                    drp.get_tx_with_speedup_data(program_context, PRE_COMMITMENT, 0, 0, true)?;
+                    drp.get_tx_with_speedup_data(program_context, POST_COMMITMENT, 0, 0, true)?;
                 program_context.bitcoin_coordinator.dispatch(
                     tx,
                     Some(sp),
@@ -791,504 +934,409 @@ pub fn handle_tx_news(
                     None,
                     None, // Receive news on every confirmation.
                 )?;
-            } else {
-                //Prover
-                let (def, _program_definition) = drp.get_program_definition(program_context)?;
-                let full_input = unify_inputs(&drp.ctx.id, program_context, &def)?;
-                program_context.globals.set_var(
-                    &drp.ctx.id,
-                    "full_input",
-                    VariableTypes::Input(full_input.clone()),
+            }
+
+            if name == POST_COMMITMENT || name.starts_with("NARY_VERIFIER") {
+                let round = name
+                    .strip_prefix("NARY_VERIFIER_")
+                    .unwrap_or("0")
+                    .parse::<u32>()?;
+
+                if round == 0 {
+                    drp.decode_witness_from_speedup(
+                        tx_id,
+                        vout,
+                        &name,
+                        program_context,
+                        &tx_status.tx,
+                        None,
+                    )?;
+                }
+
+                handle_nary_verifier(
+                    &name,
+                    drp,
+                    program_context,
+                    tx_id,
+                    vout,
+                    &tx_status,
+                    current_height,
+                    &fail_force_config,
+                    "verifier_selection_bits",
+                    POST_COMMITMENT,
+                    EXECUTE,
+                    0,
+                    round,
+                    NArySearchType::ConflictStep,
+                )?;
+            }
+
+            if (name.starts_with("NARY_PROVER")) && drp.role() == ParticipantRole::Verifier {
+                handle_nary_prover(
+                    &name,
+                    drp,
+                    program_context,
+                    tx_id,
+                    vout,
+                    &tx_status,
+                    &fail_force_config,
+                    "NARY_PROVER_",
+                    "prover_hash",
+                    NArySearchType::ConflictStep,
+                )?;
+            }
+
+            if name == EXECUTE && drp.role() == ParticipantRole::Verifier {
+                let (_, leaf) = drp.decode_witness_from_speedup(
+                    tx_id,
+                    vout,
+                    &name,
+                    program_context,
+                    &tx_status.tx,
+                    None,
+                )?;
+
+                // leaf 0 is prover_challenge_step, we lost
+                if leaf == 0 {
+                    return Ok(());
+                }
+
+                let (_program_definition, pdf) = drp.get_program_definition(program_context)?;
+                let execution_path = drp.get_execution_path()?;
+
+                let mut values = std::collections::HashMap::new();
+
+                let trace_vars = TRACE_VARS
+                    .get()
+                    .expect("TRACE_VARS not initialized")
+                    .read()?;
+                for (name, _) in trace_vars.iter() {
+                    if *name == "prover_witness" {
+                        continue;
+                    }
+                    if let Some(value) = program_context.witness.get_witness(&drp.ctx.id, name)? {
+                        values.insert(name.clone(), value.winternitz()?.message_bytes());
+                    } else {
+                        return Err(BitVMXError::VariableNotFound(drp.ctx.id, name.to_string()));
+                    }
+                }
+                fn to_u8(bytes: &[u8]) -> u8 {
+                    u8::from_be_bytes(bytes.try_into().expect("Expected 1 byte for u8"))
+                }
+                fn to_u32(bytes: &[u8]) -> u32 {
+                    u32::from_be_bytes(bytes.try_into().expect("Expected 4 bytes for u32"))
+                }
+                fn to_u64(bytes: &[u8]) -> u64 {
+                    u64::from_be_bytes(bytes.try_into().expect("Expected 8 bytes for u64"))
+                }
+                fn to_hex(bytes: &[u8]) -> String {
+                    hex::encode(bytes)
+                }
+
+                let step_number = to_u64(&values["prover_step_number"]);
+                let trace_read1 = TraceRead::new(
+                    to_u32(&values["prover_read_1_address"]),
+                    to_u32(&values["prover_read_1_value"]),
+                    to_u64(&values["prover_read_1_last_step"]),
+                );
+                let trace_read2 = TraceRead::new(
+                    to_u32(&values["prover_read_2_address"]),
+                    to_u32(&values["prover_read_2_value"]),
+                    to_u64(&values["prover_read_2_last_step"]),
+                );
+                let program_counter = ProgramCounter::new(
+                    to_u32(&values["prover_read_pc_address"]),
+                    to_u8(&values["prover_read_pc_micro"]),
+                );
+                let read_pc =
+                    TraceReadPC::new(program_counter, to_u32(&values["prover_read_pc_opcode"]));
+                let trace_write = TraceWrite::new(
+                    to_u32(&values["prover_write_address"]),
+                    to_u32(&values["prover_write_value"]),
+                );
+                let program_counter = ProgramCounter::new(
+                    to_u32(&values["prover_write_pc"]),
+                    to_u8(&values["prover_write_micro"]),
+                );
+                let trace_step = TraceStep::new(trace_write, program_counter);
+                let witness = program_context
+                    .witness
+                    .get_witness(&drp.ctx.id, "prover_witness")
+                    .ok()
+                    .flatten()
+                    .and_then(|witness| {
+                        witness.winternitz().ok().map(|w| {
+                            let bytes = w.message_bytes();
+                            to_u32(&bytes)
+                        })
+                    });
+                let mem_witness = MemoryWitness::from_byte(to_u8(&values["prover_mem_witness"]));
+                let prover_step_hash = to_hex(&values["prover_step_hash_tk"]);
+                let prover_next_hash = to_hex(&values["prover_next_hash_tk"]);
+                let _conflict_step = to_u64(&values["prover_conflict_step_tk"]);
+
+                let final_trace = TraceRWStep::new(
+                    step_number,
+                    trace_read1,
+                    trace_read2,
+                    read_pc,
+                    trace_step,
+                    witness,
+                    mem_witness,
+                );
+                let msg = serde_json::to_string(&DispatcherJob {
+                    job_id: drp.ctx.id.to_string(),
+                    job_type: EmulatorJobType::VerifierChooseChallenge(
+                        pdf,
+                        execution_path.clone(),
+                        final_trace,
+                        prover_step_hash,
+                        prover_next_hash,
+                        format!("{}/{}", execution_path, "execution.json").to_string(),
+                        fail_force_config.main.fail_config_verifier.clone(),
+                        fail_force_config.main.force_challenge.clone(),
+                    ),
+                })?;
+                program_context
+                    .broker_channel
+                    .send(&program_context.components_config.emulator, msg)?;
+            }
+
+            if name == CHALLENGE && drp.role() == ParticipantRole::Prover {
+                let (names, leaf) = drp.decode_witness_from_speedup(
+                    tx_id,
+                    vout,
+                    &name,
+                    program_context,
+                    &tx_status.tx,
+                    None,
+                )?;
+
+                let read_value_nary_search_leaf = program_context
+                    .globals
+                    .get_var(
+                        &drp.ctx.id,
+                        &format!("challenge_leaf_start_{}", "read_value_nary_search"),
+                    )?
+                    .ok_or_else(|| {
+                        BitVMXError::VariableNotFound(
+                            drp.ctx.id,
+                            format!("challenge_leaf_start_{}", "read_value_nary_search"),
+                        )
+                    })?
+                    .number()? as u32;
+
+                match leaf {
+                    l if l == read_value_nary_search_leaf => {
+                        let mut expected_names: Vec<&str> = READ_VALUE_NARY_SEARCH_CHALLENGE
+                            .iter()
+                            .map(|(name, _)| *name)
+                            .collect();
+
+                        expected_names.insert(0, "prover_continue");
+
+                        if names == expected_names {
+                            let bits_name = &names[1];
+                            let witness = program_context
+                                .witness
+                                .get_witness(&drp.ctx.id, bits_name)?
+                                .ok_or_else(|| {
+                                    BitVMXError::VariableNotFound(drp.ctx.id, bits_name.to_string())
+                                })?;
+                            let bytes = witness.winternitz()?.message_bytes();
+                            info!(
+                        "Challenge will be extended with a 2nd nary search. {bits_name} are {:?}",
+                        bytes
+                    );
+                            assert_eq!(bytes.len(), 1);
+                            let selection_bits = bytes[0] as u32;
+                            handle_nary_verifier(
+                                &name,
+                                drp,
+                                program_context,
+                                tx_id,
+                                vout,
+                                &tx_status,
+                                current_height,
+                                &fail_force_config,
+                                "verifier_selection_bits2",
+                                CHALLENGE,
+                                CHALLENGE_READ,
+                                selection_bits,
+                                1, // round 2
+                                NArySearchType::ReadValueChallenge,
+                            )?;
+                        } else {
+                            panic!(
+                                "The challenge leaf does not match the expected witness names.\n\
+                 Expected: {:?}, got: {:?}",
+                                expected_names, names
+                            );
+                        }
+                    }
+                    _ => {
+                        if fail_force_config.prover_force_second_nary {
+                            // for testing purposes we will try to start the second nary search but it should fail
+                            let selection_bits = 0;
+                            handle_nary_verifier(
+                                &name,
+                                drp,
+                                program_context,
+                                tx_id,
+                                vout,
+                                &tx_status,
+                                current_height,
+                                &fail_force_config,
+                                "verifier_selection_bits2",
+                                CHALLENGE,
+                                CHALLENGE_READ,
+                                selection_bits,
+                                1, // round 2
+                                NArySearchType::ReadValueChallenge,
+                            )?;
+                        } else {
+                            info!("Challenge ended successfully");
+                        }
+                    }
+                }
+            }
+
+            if name.starts_with("NARY2_VERIFIER") {
+                let round = name
+                    .strip_prefix("NARY2_VERIFIER_")
+                    .ok_or_else(|| BitVMXError::InvalidStringOperation(name.clone()))?
+                    .parse::<u32>()?;
+                handle_nary_verifier(
+                    &name,
+                    drp,
+                    program_context,
+                    tx_id,
+                    vout,
+                    &tx_status,
+                    current_height,
+                    &fail_force_config,
+                    "verifier_selection_bits2",
+                    CHALLENGE,
+                    CHALLENGE_READ,
+                    0, // Will be ignored
+                    round,
+                    NArySearchType::ReadValueChallenge,
+                )?;
+            }
+
+            if name.starts_with("NARY2_PROVER") && drp.role() == ParticipantRole::Verifier {
+                handle_nary_prover(
+                    &name,
+                    drp,
+                    program_context,
+                    tx_id,
+                    vout,
+                    &tx_status,
+                    &fail_force_config,
+                    "NARY2_PROVER_",
+                    "prover_hash2",
+                    NArySearchType::ReadValueChallenge,
+                )?;
+            }
+
+            if GET_HASHES_AND_STEP == name && drp.role() == ParticipantRole::Verifier {
+                let (_, leaf) = drp.decode_witness_from_speedup(
+                    tx_id,
+                    vout,
+                    &name,
+                    program_context,
+                    &tx_status.tx,
+                    None,
+                )?;
+
+                // leaf 0 is prover_challenge_step2, we lost
+                if leaf == 0 {
+                    return Ok(());
+                }
+
+                let (_program_definition, pdf) = drp.get_program_definition(program_context)?;
+                let execution_path = drp.get_execution_path()?;
+
+                let mut values = std::collections::HashMap::new();
+
+                let trace_vars = TK_2NARY.get().expect("TK_2NARY not initialized").read()?;
+                for (name, _) in trace_vars.iter() {
+                    if let Some(value) = program_context.witness.get_witness(&drp.ctx.id, name)? {
+                        values.insert(name.clone(), value.winternitz()?.message_bytes());
+                    } else {
+                        return Err(BitVMXError::VariableNotFound(drp.ctx.id, name.to_string()));
+                    }
+                }
+                fn to_u64(bytes: &[u8]) -> u64 {
+                    u64::from_be_bytes(bytes.try_into().expect("Expected 8 bytes for u64"))
+                }
+                fn to_hex(bytes: &[u8]) -> String {
+                    hex::encode(bytes)
+                }
+
+                let prover_step_hash = to_hex(&values["prover_step_hash_tk2"]);
+                let prover_next_hash = to_hex(&values["prover_next_hash_tk2"]);
+                let _prover_write_step = to_u64(&values["prover_write_step_tk2"]);
+
+                let msg = serde_json::to_string(&DispatcherJob {
+                    job_id: drp.ctx.id.to_string(),
+                    job_type: EmulatorJobType::VerifierChooseChallengeForReadChallenge(
+                        pdf,
+                        execution_path.clone(),
+                        format!("{}/{}", execution_path, "execution.json").to_string(),
+                        prover_step_hash,
+                        prover_next_hash,
+                        fail_force_config.read.fail_config_verifier.clone(),
+                        fail_force_config.read.force_challenge.clone(),
+                    ),
+                })?;
+                program_context
+                    .broker_channel
+                    .send(&program_context.components_config.emulator, msg)?;
+            }
+
+            if name == CHALLENGE_READ && drp.role() == ParticipantRole::Prover {
+                info!("The challenge has ended after the 2nd n-ary search.");
+                drp.decode_witness_from_speedup(
+                    tx_id,
+                    vout,
+                    &name,
+                    program_context,
+                    &tx_status.tx,
+                    None,
+                )?;
+            }
+        }
+        None => {
+            if CHALLENGE_READ == name && ParticipantRole::Verifier == drp.role() {
+                let verifier_final_tx =
+                    drp.get_signed_tx(program_context, &VERIFIER_FINAL, 0, 0, false, 0)?;
+                let speedup_data =
+                    drp.get_speedup_data_from_tx(&verifier_final_tx, program_context, None)?;
+                program_context.bitcoin_coordinator.dispatch(
+                    verifier_final_tx,
+                    Some(speedup_data),
+                    Context::ProgramId(drp.ctx.id).to_string()?,
+                    Some(current_height + 2 * timelock_blocks as u32),
+                    None, // Receive news on every confirmation.
+                )?;
+            }
+
+            if VERIFIER_FINAL == name && ParticipantRole::Verifier == drp.role() {
+                let claim_name = ClaimGate::tx_start(VERIFIER_WINS);
+                let tx = drp.get_signed_tx(program_context, &claim_name, 0, 0, false, 0)?;
+                let speedup_data = drp.get_speedup_data_from_tx(&tx, program_context, None)?;
+                info!("{claim_name}: {:?}", tx);
+                program_context.bitcoin_coordinator.dispatch(
+                    tx,
+                    Some(speedup_data),
+                    Context::ProgramId(drp.ctx.id).to_string()?,
+                    None,
+                    None, // Receive news on every confirmation.
                 )?;
             }
         }
     }
-
-    if name == PRE_COMMITMENT && drp.role() == ParticipantRole::Prover && vout.is_some() {
-        let (_def, program_definition) = drp.get_program_definition(program_context)?;
-        let execution_path = drp.get_execution_path()?;
-        let full_input = program_context
-            .globals
-            .get_var(&drp.ctx.id, "full_input")?
-            .unwrap()
-            .input()?;
-        let msg = serde_json::to_string(&DispatcherJob {
-            job_id: drp.ctx.id.to_string(),
-            job_type: EmulatorJobType::ProverExecute(
-                program_definition,
-                full_input,
-                execution_path.clone(),
-                format!("{}/{}", execution_path, "execution.json").to_string(),
-                fail_force_config.main.fail_config_prover.clone(),
-            ),
-        })?;
-        program_context
-            .broker_channel
-            .send(&program_context.components_config.emulator, msg)?;
-    }
-
-    if name == COMMITMENT && drp.role() == ParticipantRole::Verifier && vout.is_some() {
-        drp.decode_witness_from_speedup(
-            tx_id,
-            vout.unwrap(),
-            &name,
-            program_context,
-            &tx_status.tx,
-            None,
-        )?;
-
-        let execution_path = drp.get_execution_path()?;
-
-        let (def, program_definition) = drp.get_program_definition(program_context)?;
-        let input_program = unify_inputs(&drp.ctx.id, program_context, &def)?;
-
-        let last_hash = program_context
-            .witness
-            .get_witness(&drp.ctx.id, "prover_last_hash")?
-            .unwrap()
-            .winternitz()?
-            .message_bytes();
-
-        let last_step = program_context
-            .witness
-            .get_witness(&drp.ctx.id, "prover_last_step")?
-            .unwrap()
-            .winternitz()?
-            .message_bytes();
-        let last_step = u64::from_be_bytes(last_step.try_into().unwrap());
-        set_input_u64(
-            &drp.ctx.id,
-            program_context,
-            "verifier_last_step_tk",
-            last_step,
-        )?;
-
-        let msg = serde_json::to_string(&DispatcherJob {
-            job_id: drp.ctx.id.to_string(),
-            job_type: EmulatorJobType::VerifierCheckExecution(
-                program_definition,
-                input_program,
-                execution_path.clone(),
-                last_step,
-                hex::encode(last_hash),
-                format!("{}/{}", execution_path, "execution.json").to_string(),
-                fail_force_config.main.force_condition.clone(),
-                fail_force_config.main.fail_config_verifier.clone(),
-            ),
-        })?;
-
-        program_context
-            .broker_channel
-            .send(&program_context.components_config.emulator, msg)?;
-
-        let (tx, sp) =
-            drp.get_tx_with_speedup_data(program_context, POST_COMMITMENT, 0, 0, true)?;
-        program_context.bitcoin_coordinator.dispatch(
-            tx,
-            Some(sp),
-            Context::ProgramId(drp.ctx.id).to_string()?,
-            None,
-            None, // Receive news on every confirmation.
-        )?;
-    }
-
-    if (name == POST_COMMITMENT || name.starts_with("NARY_VERIFIER")) && vout.is_some() {
-        let round = name
-            .strip_prefix("NARY_VERIFIER_")
-            .unwrap_or("0")
-            .parse::<u32>()
-            .unwrap();
-
-        if round == 0 {
-            drp.decode_witness_from_speedup(
-                tx_id,
-                vout.unwrap(),
-                &name,
-                program_context,
-                &tx_status.tx,
-                None,
-            )?;
-        }
-
-        handle_nary_verifier(
-            &name,
-            drp,
-            program_context,
-            tx_id,
-            vout,
-            &tx_status,
-            current_height,
-            &fail_force_config,
-            "verifier_selection_bits",
-            POST_COMMITMENT,
-            EXECUTE,
-            0,
-            round,
-            NArySearchType::ConflictStep,
-        )?;
-    }
-
-    if (name.starts_with("NARY_PROVER"))
-        && drp.role() == ParticipantRole::Verifier
-        && vout.is_some()
-    {
-        handle_nary_prover(
-            &name,
-            drp,
-            program_context,
-            tx_id,
-            vout,
-            &tx_status,
-            &fail_force_config,
-            "NARY_PROVER_",
-            "prover_hash",
-            NArySearchType::ConflictStep,
-        )?;
-    }
-
-    if name == EXECUTE && drp.role() == ParticipantRole::Verifier && vout.is_some() {
-        let (_, leaf) = drp.decode_witness_from_speedup(
-            tx_id,
-            vout.unwrap(),
-            &name,
-            program_context,
-            &tx_status.tx,
-            None,
-        )?;
-
-        // leaf 0 is prover_challenge_step, we lost
-        if leaf == 0 {
-            return Ok(());
-        }
-
-        let (_program_definition, pdf) = drp.get_program_definition(program_context)?;
-        let execution_path = drp.get_execution_path()?;
-
-        let mut values = std::collections::HashMap::new();
-
-        let trace_vars = TRACE_VARS
-            .get()
-            .expect("TRACE_VARS not initialized")
-            .read()?;
-        for (name, _) in trace_vars.iter() {
-            if *name == "prover_witness" {
-                continue;
-            }
-            if let Some(value) = program_context.witness.get_witness(&drp.ctx.id, name)? {
-                values.insert(name.clone(), value.winternitz().unwrap().message_bytes());
-            } else {
-                return Err(BitVMXError::VariableNotFound(drp.ctx.id, name.to_string()));
-            }
-        }
-        fn to_u8(bytes: &[u8]) -> u8 {
-            u8::from_be_bytes(bytes.try_into().expect("Expected 1 byte for u8"))
-        }
-        fn to_u32(bytes: &[u8]) -> u32 {
-            u32::from_be_bytes(bytes.try_into().expect("Expected 4 bytes for u32"))
-        }
-        fn to_u64(bytes: &[u8]) -> u64 {
-            u64::from_be_bytes(bytes.try_into().expect("Expected 8 bytes for u64"))
-        }
-        fn to_hex(bytes: &[u8]) -> String {
-            hex::encode(bytes)
-        }
-
-        let step_number = to_u64(&values["prover_step_number"]);
-        let trace_read1 = TraceRead::new(
-            to_u32(&values["prover_read_1_address"]),
-            to_u32(&values["prover_read_1_value"]),
-            to_u64(&values["prover_read_1_last_step"]),
-        );
-        let trace_read2 = TraceRead::new(
-            to_u32(&values["prover_read_2_address"]),
-            to_u32(&values["prover_read_2_value"]),
-            to_u64(&values["prover_read_2_last_step"]),
-        );
-        let program_counter = ProgramCounter::new(
-            to_u32(&values["prover_read_pc_address"]),
-            to_u8(&values["prover_read_pc_micro"]),
-        );
-        let read_pc = TraceReadPC::new(program_counter, to_u32(&values["prover_read_pc_opcode"]));
-        let trace_write = TraceWrite::new(
-            to_u32(&values["prover_write_address"]),
-            to_u32(&values["prover_write_value"]),
-        );
-        let program_counter = ProgramCounter::new(
-            to_u32(&values["prover_write_pc"]),
-            to_u8(&values["prover_write_micro"]),
-        );
-        let trace_step = TraceStep::new(trace_write, program_counter);
-        let witness = program_context
-            .witness
-            .get_witness(&drp.ctx.id, "prover_witness")
-            .ok()
-            .flatten()
-            .map(|witness| {
-                let bytes = witness.winternitz().unwrap().message_bytes();
-                to_u32(&bytes)
-            });
-        let mem_witness = MemoryWitness::from_byte(to_u8(&values["prover_mem_witness"]));
-        let prover_step_hash = to_hex(&values["prover_step_hash_tk"]);
-        let prover_next_hash = to_hex(&values["prover_next_hash_tk"]);
-        let _conflict_step = to_u64(&values["prover_conflict_step_tk"]);
-
-        let final_trace = TraceRWStep::new(
-            step_number,
-            trace_read1,
-            trace_read2,
-            read_pc,
-            trace_step,
-            witness,
-            mem_witness,
-        );
-        let msg = serde_json::to_string(&DispatcherJob {
-            job_id: drp.ctx.id.to_string(),
-            job_type: EmulatorJobType::VerifierChooseChallenge(
-                pdf,
-                execution_path.clone(),
-                final_trace,
-                prover_step_hash,
-                prover_next_hash,
-                format!("{}/{}", execution_path, "execution.json").to_string(),
-                fail_force_config.main.fail_config_verifier.clone(),
-                fail_force_config.main.force_challenge.clone(),
-            ),
-        })?;
-        program_context
-            .broker_channel
-            .send(&program_context.components_config.emulator, msg)?;
-    }
-
-    if name == CHALLENGE && drp.role() == ParticipantRole::Prover && vout.is_some() {
-        let (names, leaf) = drp.decode_witness_from_speedup(
-            tx_id,
-            vout.unwrap(),
-            &name,
-            program_context,
-            &tx_status.tx,
-            None,
-        )?;
-
-        let read_value_nary_search_leaf = program_context
-            .globals
-            .get_var(
-                &drp.ctx.id,
-                &format!("challenge_leaf_start_{}", "read_value_nary_search"),
-            )?
-            .unwrap()
-            .number()? as u32;
-
-        match leaf {
-            l if l == read_value_nary_search_leaf => {
-                let mut expected_names: Vec<&str> = READ_VALUE_NARY_SEARCH_CHALLENGE
-                    .iter()
-                    .map(|(name, _)| *name)
-                    .collect();
-
-                expected_names.insert(0, "prover_continue");
-
-                if names == expected_names {
-                    let bits_name = &names[1];
-                    let witness = program_context
-                        .witness
-                        .get_witness(&drp.ctx.id, bits_name)?
-                        .ok_or_else(|| {
-                            BitVMXError::VariableNotFound(drp.ctx.id, bits_name.to_string())
-                        })?;
-                    let bytes = witness.winternitz()?.message_bytes();
-                    info!(
-                        "Challenge will be extended with a 2nd nary search. {bits_name} are {:?}",
-                        bytes
-                    );
-                    assert_eq!(bytes.len(), 1);
-                    let selection_bits = bytes[0] as u32;
-                    handle_nary_verifier(
-                        &name,
-                        drp,
-                        program_context,
-                        tx_id,
-                        vout,
-                        &tx_status,
-                        current_height,
-                        &fail_force_config,
-                        "verifier_selection_bits2",
-                        CHALLENGE,
-                        CHALLENGE_READ,
-                        selection_bits,
-                        1, // round 2
-                        NArySearchType::ReadValueChallenge,
-                    )?;
-                } else {
-                    panic!(
-                        "The challenge leaf does not match the expected witness names.\n\
-                 Expected: {:?}, got: {:?}",
-                        expected_names, names
-                    );
-                }
-            }
-            _ => {
-                if fail_force_config.prover_force_second_nary {
-                    // for testing purposes we will try to start the second nary search but it should fail
-                    let selection_bits = 0;
-                    handle_nary_verifier(
-                        &name,
-                        drp,
-                        program_context,
-                        tx_id,
-                        vout,
-                        &tx_status,
-                        current_height,
-                        &fail_force_config,
-                        "verifier_selection_bits2",
-                        CHALLENGE,
-                        CHALLENGE_READ,
-                        selection_bits,
-                        1, // round 2
-                        NArySearchType::ReadValueChallenge,
-                    )?;
-                } else {
-                    info!("Challenge ended successfully");
-                }
-            }
-        }
-    }
-
-    if name.starts_with("NARY2_VERIFIER") && vout.is_some() {
-        let round = name
-            .strip_prefix("NARY2_VERIFIER_")
-            .unwrap()
-            .parse::<u32>()
-            .unwrap();
-        handle_nary_verifier(
-            &name,
-            drp,
-            program_context,
-            tx_id,
-            vout,
-            &tx_status,
-            current_height,
-            &fail_force_config,
-            "verifier_selection_bits2",
-            CHALLENGE,
-            CHALLENGE_READ,
-            0, // Will be ignored
-            round,
-            NArySearchType::ReadValueChallenge,
-        )?;
-    }
-
-    if name.starts_with("NARY2_PROVER") && drp.role() == ParticipantRole::Verifier && vout.is_some()
-    {
-        handle_nary_prover(
-            &name,
-            drp,
-            program_context,
-            tx_id,
-            vout,
-            &tx_status,
-            &fail_force_config,
-            "NARY2_PROVER_",
-            "prover_hash2",
-            NArySearchType::ReadValueChallenge,
-        )?;
-    }
-
-    if GET_HASHES_AND_STEP == name && drp.role() == ParticipantRole::Verifier && vout.is_some() {
-        let (_, leaf) = drp.decode_witness_from_speedup(
-            tx_id,
-            vout.unwrap(),
-            &name,
-            program_context,
-            &tx_status.tx,
-            None,
-        )?;
-
-        // leaf 0 is prover_challenge_step2, we lost
-        if leaf == 0 {
-            return Ok(());
-        }
-
-        let (_program_definition, pdf) = drp.get_program_definition(program_context)?;
-        let execution_path = drp.get_execution_path()?;
-
-        let mut values = std::collections::HashMap::new();
-
-        let trace_vars = TK_2NARY.get().expect("TK_2NARY not initialized").read()?;
-        for (name, _) in trace_vars.iter() {
-            if let Some(value) = program_context.witness.get_witness(&drp.ctx.id, name)? {
-                values.insert(name.clone(), value.winternitz().unwrap().message_bytes());
-            } else {
-                return Err(BitVMXError::VariableNotFound(drp.ctx.id, name.to_string()));
-            }
-        }
-        fn to_u64(bytes: &[u8]) -> u64 {
-            u64::from_be_bytes(bytes.try_into().expect("Expected 8 bytes for u64"))
-        }
-        fn to_hex(bytes: &[u8]) -> String {
-            hex::encode(bytes)
-        }
-
-        let prover_step_hash = to_hex(&values["prover_step_hash_tk2"]);
-        let prover_next_hash = to_hex(&values["prover_next_hash_tk2"]);
-        let _prover_write_step = to_u64(&values["prover_write_step_tk2"]);
-
-        let msg = serde_json::to_string(&DispatcherJob {
-            job_id: drp.ctx.id.to_string(),
-            job_type: EmulatorJobType::VerifierChooseChallengeForReadChallenge(
-                pdf,
-                execution_path.clone(),
-                format!("{}/{}", execution_path, "execution.json").to_string(),
-                prover_step_hash,
-                prover_next_hash,
-                fail_force_config.read.fail_config_verifier.clone(),
-                fail_force_config.read.force_challenge.clone(),
-            ),
-        })?;
-        program_context
-            .broker_channel
-            .send(&program_context.components_config.emulator, msg)?;
-    }
-
-    if name == CHALLENGE_READ && drp.role() == ParticipantRole::Prover && vout.is_some() {
-        info!("The challenge has ended after the 2nd n-ary search.");
-        drp.decode_witness_from_speedup(
-            tx_id,
-            vout.unwrap(),
-            &name,
-            program_context,
-            &tx_status.tx,
-            None,
-        )?;
-    }
-
-    if CHALLENGE_READ == name && ParticipantRole::Verifier == drp.role() && vout.is_none() {
-        let verifier_final_tx =
-            drp.get_signed_tx(program_context, &VERIFIER_FINAL, 0, 0, false, 0)?;
-        let speedup_data =
-            drp.get_speedup_data_from_tx(&verifier_final_tx, program_context, None)?;
-        program_context.bitcoin_coordinator.dispatch(
-            verifier_final_tx,
-            Some(speedup_data),
-            Context::ProgramId(drp.ctx.id).to_string()?,
-            Some(current_height + 2 * timelock_blocks as u32),
-            None, // Receive news on every confirmation.
-        )?;
-    }
-
-    if VERIFIER_FINAL == name && ParticipantRole::Verifier == drp.role() && vout.is_none() {
-        let claim_name = ClaimGate::tx_start(VERIFIER_WINS);
-        let tx = drp.get_signed_tx(program_context, &claim_name, 0, 0, false, 0)?;
-        let speedup_data = drp.get_speedup_data_from_tx(&tx, program_context, None)?;
-        info!("{claim_name}: {:?}", tx);
-        program_context.bitcoin_coordinator.dispatch(
-            tx,
-            Some(speedup_data),
-            Context::ProgramId(drp.ctx.id).to_string()?,
-            None,
-            None, // Receive news on every confirmation.
-        )?;
-    }
-
     Ok(())
 }
 
@@ -1297,7 +1345,7 @@ fn handle_nary_verifier(
     drp: &DisputeResolutionProtocol,
     program_context: &ProgramContext,
     tx_id: Txid,
-    vout: Option<u32>,
+    vout: u32,
     tx_status: &TransactionStatus,
     current_height: u32,
     fail_force_config: &ForceFailConfiguration,
@@ -1327,7 +1375,7 @@ fn handle_nary_verifier(
         } else {
             drp.decode_witness_from_speedup(
                 tx_id,
-                vout.unwrap(),
+                vout,
                 &name,
                 program_context,
                 &tx_status.tx,
@@ -1337,7 +1385,12 @@ fn handle_nary_verifier(
             let bits = program_context
                 .witness
                 .get_witness(&drp.ctx.id, &format!("{}_{}", selection_bits, round))?
-                .unwrap()
+                .ok_or_else(|| {
+                    BitVMXError::VariableNotFound(
+                        drp.ctx.id,
+                        format!("{}_{}", selection_bits, round),
+                    )
+                })?
                 .winternitz()?
                 .message_bytes();
             assert!(bits.len() == 1);
@@ -1410,26 +1463,20 @@ fn handle_nary_prover(
     drp: &DisputeResolutionProtocol,
     program_context: &ProgramContext,
     tx_id: Txid,
-    vout: Option<u32>,
+    vout: u32,
     tx_status: &TransactionStatus,
     fail_force_config: &ForceFailConfiguration,
     strip_prefix: &str,               // "NARY_PROVER_"
     prover_hash: &str,                // "prover_hash"
     nary_search_type: NArySearchType, // ConflictStep
 ) -> Result<(), BitVMXError> {
-    let (_, leaf) = drp.decode_witness_from_speedup(
-        tx_id,
-        vout.unwrap(),
-        &name,
-        program_context,
-        &tx_status.tx,
-        None,
-    )?;
+    let (_, leaf) =
+        drp.decode_witness_from_speedup(tx_id, vout, &name, program_context, &tx_status.tx, None)?;
 
     let params = program_context
         .globals
         .get_var(&drp.ctx.id, &timeout_input_tx(name))?
-        .unwrap()
+        .ok_or_else(|| BitVMXError::VariableNotFound(drp.ctx.id, timeout_input_tx(name)))?
         .vec_number()?;
     let timeout_leaf = params[1];
     if leaf == timeout_leaf {
@@ -1466,20 +1513,20 @@ fn handle_nary_prover(
     let hashes_count = nary.hashes_for_round(round as u8);
     let execution_path = drp.get_execution_path()?;
 
-    let hashes: Vec<String> = (1..hashes_count + 1)
-        .map(|h| {
-            hex::encode(
-                program_context
-                    .witness
-                    .get_witness(&drp.ctx.id, &format!("{}_{}_{}", prover_hash, round, h))
-                    .unwrap()
-                    .unwrap()
-                    .winternitz()
-                    .unwrap()
-                    .message_bytes(),
-            )
+    let hashes: Vec<String> = (1..=hashes_count)
+        .map(|h| -> Result<String, BitVMXError> {
+            let name = format!("{}_{}_{}", prover_hash, round, h);
+
+            let bytes = program_context
+                .witness
+                .get_witness(&drp.ctx.id, &name)?
+                .ok_or_else(|| BitVMXError::VariableNotFound(drp.ctx.id, name.clone()))?
+                .winternitz()?
+                .message_bytes();
+
+            Ok(hex::encode(bytes))
         })
-        .collect();
+        .collect::<Result<_, _>>()?;
 
     let msg = serde_json::to_string(&DispatcherJob {
         job_id: drp.ctx.id.to_string(),

--- a/src/program/protocols/protocol_handler.rs
+++ b/src/program/protocols/protocol_handler.rs
@@ -472,8 +472,7 @@ pub trait ProtocolHandler {
     fn get_speedup_key(&self, program_context: &ProgramContext) -> Result<PublicKey, BitVMXError> {
         program_context
             .globals
-            .get_var(&self.context().id, "speedup")?
-            .ok_or_else(|| BitVMXError::VariableNotFound(self.context().id, "speedup".to_string()))?
+            .get_var_or_err(&self.context().id, "speedup")?
             .pubkey()
     }
 

--- a/src/program/protocols/protocol_handler.rs
+++ b/src/program/protocols/protocol_handler.rs
@@ -86,22 +86,19 @@ pub trait ProtocolHandler {
         input_index: u32,
         message_index: u32,
     ) -> Result<String, BitVMXError> {
-        let ret = self.load_protocol()?.get_hashed_message(
-            transaction_name,
-            input_index,
-            message_index,
-        )?;
-        if ret.is_none() {
-            error!(
-                "Invalid transaction name when getting hashed message: {}. Protocol ID: {}",
-                transaction_name,
-                self.context().id
-            );
-            return Err(BitVMXError::InvalidTransactionName(
-                transaction_name.to_string(),
-            ));
-        }
-        Ok(format!("{}", ret.unwrap()))
+        let ret = self
+            .load_protocol()?
+            .get_hashed_message(transaction_name, input_index, message_index)?
+            .ok_or_else(|| {
+                error!(
+                    "Invalid transaction name when getting hashed message: {}. Protocol ID: {}",
+                    transaction_name,
+                    self.context().id
+                );
+                BitVMXError::InvalidTransactionName(transaction_name.to_string())
+            })?;
+
+        Ok(format!("{}", ret))
     }
 
     fn get_transaction_by_id(&self, txid: &Txid) -> Result<Transaction, ProtocolBuilderError> {
@@ -173,7 +170,12 @@ pub trait ProtocolHandler {
     fn load_protocol(&self) -> Result<Protocol, ProtocolBuilderError> {
         match Protocol::load(
             &self.context().protocol_name,
-            self.context().storage.clone().unwrap(),
+            self.context()
+                .storage
+                .clone()
+                .ok_or(ProtocolBuilderError::MissingStorage(
+                    self.context().protocol_name.clone(),
+                ))?,
         )? {
             Some(protocol) => Ok(protocol),
             None => Err(ProtocolBuilderError::MissingProtocol(
@@ -191,7 +193,9 @@ pub trait ProtocolHandler {
     }
 
     fn save_protocol(&self, protocol: Protocol) -> Result<(), ProtocolBuilderError> {
-        protocol.save(self.context().storage.clone().unwrap())?;
+        protocol.save(self.context().storage.clone().ok_or(
+            ProtocolBuilderError::MissingStorage(self.context().protocol_name.clone()),
+        )?)?;
         Ok(())
     }
 
@@ -251,7 +255,7 @@ pub trait ProtocolHandler {
                         WinternitzType::HASH160,
                         protocol_script
                             .get_key(k.name())
-                            .unwrap()
+                            .ok_or(BitVMXError::KeysNotFound(self.context().id))?
                             .derivation_index(),
                     )?;
 
@@ -320,7 +324,10 @@ pub trait ProtocolHandler {
         if total_inputs > 1 {
             let signature = protocol
                 .input_taproot_script_spend_signature(name, 1, second_leaf_index)?
-                .unwrap();
+                .expect(&format!(
+                    "Failed to get taproot signature for tx {} input {} leaf {}",
+                    name, input_index, leaf_index
+                ));
             let mut spending_args = InputArgs::new_taproot_script_args(second_leaf_index);
             spending_args.push_taproot_signature(signature)?;
             args.push(spending_args);
@@ -351,7 +358,11 @@ pub trait ProtocolHandler {
         let leaf = match leaf {
             Some(idx) => idx,
             None => {
-                let leaf = read_scriptint(witness.third_to_last().unwrap()).unwrap() as u32;
+                let leaf = read_scriptint(
+                    witness
+                        .third_to_last()
+                        .expect("Failed to get third to last witness element"),
+                )? as u32;
                 program_context.globals.set_var(
                     &self.context().id,
                     &format!("{}_{}_leaf_index", name, input_index),
@@ -375,19 +386,16 @@ pub trait ProtocolHandler {
         let mut names = vec![];
         let mut sizes = vec![];
         //TODO: make the script save the size so we don't need to get it from participant keys or variables
-        script.get_keys().iter().rev().for_each(|k| {
+        for k in script.get_keys().iter().rev() {
             names.push(k.name().to_string());
-            let size = k.key_type().winternitz_message_size();
-            if size.is_err() {
-                error!(
-                    "Failed to get key size for {}: {}",
-                    k.name(),
-                    size.err().unwrap()
-                );
-                return;
-            }
-            sizes.push(message_bytes_length(size.unwrap()));
-        });
+
+            let size = k.key_type().winternitz_message_size().map_err(|e| {
+                error!("Failed to get key size for {}: {}", k.name(), e);
+                e
+            })?;
+            sizes.push(message_bytes_length(size));
+        }
+
         info!("Decoding data for {}", name);
         info!("Names: {:?}", names);
         info!("Sizes: {:?}", sizes);
@@ -461,7 +469,10 @@ pub trait ProtocolHandler {
         program_context
             .globals
             .get_var(&self.context().id, "speedup")?
-            .unwrap()
+            .ok_or(BitVMXError::VariableNotFound(
+                self.context().id,
+                "speedup".to_string(),
+            ))?
             .pubkey()
     }
 
@@ -492,7 +503,13 @@ pub trait ProtocolHandler {
             protocol_id,
             name,
             self.context().my_idx,
-            self.context().storage.as_ref().unwrap().clone(),
+            self.context()
+                .storage
+                .as_ref()
+                .ok_or(BitVMXError::StorageUnavailable(
+                    self.context().protocol_name.clone(),
+                ))?
+                .clone(),
         )
     }
 

--- a/src/program/protocols/protocol_handler.rs
+++ b/src/program/protocols/protocol_handler.rs
@@ -255,7 +255,7 @@ pub trait ProtocolHandler {
                         WinternitzType::HASH160,
                         protocol_script
                             .get_key(k.name())
-                            .ok_or(BitVMXError::KeysNotFound(self.context().id))?
+                            .ok_or_else(|| BitVMXError::KeysNotFound(self.context().id))?
                             .derivation_index(),
                     )?;
 
@@ -469,10 +469,7 @@ pub trait ProtocolHandler {
         program_context
             .globals
             .get_var(&self.context().id, "speedup")?
-            .ok_or(BitVMXError::VariableNotFound(
-                self.context().id,
-                "speedup".to_string(),
-            ))?
+            .ok_or_else(|| BitVMXError::VariableNotFound(self.context().id, "speedup".to_string()))?
             .pubkey()
     }
 
@@ -506,9 +503,9 @@ pub trait ProtocolHandler {
             self.context()
                 .storage
                 .as_ref()
-                .ok_or(BitVMXError::StorageUnavailable(
-                    self.context().protocol_name.clone(),
-                ))?
+                .ok_or_else(|| {
+                    BitVMXError::StorageUnavailable(self.context().protocol_name.clone())
+                })?
                 .clone(),
         )
     }

--- a/src/program/variables.rs
+++ b/src/program/variables.rs
@@ -137,13 +137,14 @@ impl Globals {
         Ok(value)
     }
 
+    pub fn get_var_or_err(&self, uuid: &Uuid, key: &str) -> Result<VariableTypes, BitVMXError> {
+        self.get_var(uuid, key)?
+            .ok_or_else(|| BitVMXError::VariableNotFound(*uuid, key.to_string()))
+    }
+
     pub fn copy_var(&self, from: &Uuid, to: &Uuid, key: &str) -> Result<(), BitVMXError> {
-        let value = self.get_var(from, key)?;
-        if let Some(value) = value {
-            self.set_var(to, key, value)?;
-        } else {
-            return Err(BitVMXError::VariableNotFound(from.clone(), key.to_string()));
-        }
+        let value = self.get_var_or_err(from, key)?;
+        self.set_var(to, key, value)?;
         Ok(())
     }
 

--- a/src/program/variables.rs
+++ b/src/program/variables.rs
@@ -205,13 +205,14 @@ impl WitnessVars {
         Ok(value)
     }
 
+    pub fn get_witness_or_err(&self, uuid: &Uuid, key: &str) -> Result<WitnessTypes, BitVMXError> {
+        self.get_witness(uuid, key)?
+            .ok_or_else(|| BitVMXError::VariableNotFound(*uuid, key.to_string()))
+    }
+
     pub fn copy_witness(&self, from: &Uuid, to: &Uuid, key: &str) -> Result<(), BitVMXError> {
-        let value = self.get_witness(from, key)?;
-        if let Some(value) = value {
-            self.set_witness(to, key, value)?;
-        } else {
-            return Err(BitVMXError::VariableNotFound(from.clone(), key.to_string()));
-        }
+        let value = self.get_witness_or_err(from, key)?;
+        self.set_witness(to, key, value)?;
         Ok(())
     }
 }

--- a/src/spv_proof.rs
+++ b/src/spv_proof.rs
@@ -182,7 +182,7 @@ fn build_merkle_branch(
 
         let hash = clean_merkle_tree
             .get((level_offset + target_offset) as usize)
-            .ok_or(BitVMXError::InvalidMerkleTree)?;
+            .ok_or_else(|| BitVMXError::InvalidMerkleTree)?;
         hashes.push(to_swapped_bytes32(hash));
 
         level_offset += level_size;
@@ -195,11 +195,14 @@ fn build_merkle_branch(
 }
 
 fn get_merkle_tree_root_hex(merkle_tree: &Vec<Option<[u8; 32]>>) -> Result<String, BitVMXError> {
-    let last = merkle_tree.last().ok_or(BitVMXError::InvalidMerkleTree)?;
-    Ok(
-        to_swapped_bytes32(last.as_ref().ok_or(BitVMXError::InvalidMerkleTree)?)
-            .to_hex_string(Case::Lower),
+    let last = merkle_tree
+        .last()
+        .ok_or_else(|| BitVMXError::InvalidMerkleTree)?;
+    Ok(to_swapped_bytes32(
+        last.as_ref()
+            .ok_or_else(|| BitVMXError::InvalidMerkleTree)?,
     )
+    .to_hex_string(Case::Lower))
 }
 
 #[cfg(test)]

--- a/src/spv_proof.rs
+++ b/src/spv_proof.rs
@@ -41,7 +41,7 @@ pub fn get_spv_proof(txid: Txid, block_info: FullBlock) -> Result<BtcTxSPVProof,
     let merkle_tree = build_merkle_tree_store(&block_info.txs, false);
 
     // Build the merkle branch with hashes in pc endianes
-    let branch = build_merkle_branch(&merkle_tree, block_info.txs.len() as u32, tx_index as u32);
+    let branch = build_merkle_branch(&merkle_tree, block_info.txs.len() as u32, tx_index as u32)?;
     debug!(
         "Merkle Tree Root: {:#?}",
         get_merkle_tree_root_hex(&merkle_tree)
@@ -158,7 +158,7 @@ fn build_merkle_branch(
     merkle_tree: &Vec<Option<[u8; 32]>>,
     tx_count: u32,
     tx_index: u32,
-) -> MerkleBranch {
+) -> Result<MerkleBranch, BitVMXError> {
     let mut hashes = Vec::new();
     let mut path = 0;
     let mut path_index = 0;
@@ -182,7 +182,7 @@ fn build_merkle_branch(
 
         let hash = clean_merkle_tree
             .get((level_offset + target_offset) as usize)
-            .unwrap();
+            .ok_or(BitVMXError::InvalidMerkleTree)?;
         hashes.push(to_swapped_bytes32(hash));
 
         level_offset += level_size;
@@ -191,11 +191,15 @@ fn build_merkle_branch(
         level_size = (level_size + 1) / 2;
     }
 
-    MerkleBranch { hashes, path }
+    Ok(MerkleBranch { hashes, path })
 }
 
-fn get_merkle_tree_root_hex(merkle_tree: &Vec<Option<[u8; 32]>>) -> String {
-    return to_swapped_bytes32(&merkle_tree.last().unwrap().unwrap()).to_hex_string(Case::Lower);
+fn get_merkle_tree_root_hex(merkle_tree: &Vec<Option<[u8; 32]>>) -> Result<String, BitVMXError> {
+    let last = merkle_tree.last().ok_or(BitVMXError::InvalidMerkleTree)?;
+    Ok(
+        to_swapped_bytes32(last.as_ref().ok_or(BitVMXError::InvalidMerkleTree)?)
+            .to_hex_string(Case::Lower),
+    )
 }
 
 #[cfg(test)]
@@ -254,7 +258,8 @@ mod tests {
 
         // Act
         let merkle_tree = build_merkle_tree_store(&txids, false);
-        let branch = build_merkle_branch(&merkle_tree, txids.len() as u32, tx_index as u32);
+        let branch =
+            build_merkle_branch(&merkle_tree, txids.len() as u32, tx_index as u32).unwrap();
 
         // Assert
         assert_eq!(
@@ -266,7 +271,7 @@ mod tests {
         let expected_merkle_root =
             "f3e94742aca4b5ef85488dc37c06c3282295ffec960994b2c0d5ac2a25a95766";
         assert_eq!(
-            get_merkle_tree_root_hex(&merkle_tree),
+            get_merkle_tree_root_hex(&merkle_tree).unwrap(),
             expected_merkle_root,
             "Merkle root is wrong"
         );
@@ -327,7 +332,8 @@ mod tests {
                 })
                 .collect::<Vec<String>>()
         );
-        let branch = build_merkle_branch(&merkle_tree, txids.len() as u32, tx_index as u32);
+        let branch =
+            build_merkle_branch(&merkle_tree, txids.len() as u32, tx_index as u32).unwrap();
 
         // Assert
         debug!(
@@ -345,7 +351,7 @@ mod tests {
         );
         assert_eq!(branch.path, tx_index, "Merkle Branch Path is wrong");
         assert_eq!(
-            get_merkle_tree_root_hex(&merkle_tree),
+            get_merkle_tree_root_hex(&merkle_tree).unwrap(),
             "7fe79307aeb300d910d9c4bec5bacb4c7e114c7dfd6789e19f3a733debb3bb6a",
             "Merkle root is wrong"
         );

--- a/tests/common/dispute.rs
+++ b/tests/common/dispute.rs
@@ -108,7 +108,7 @@ impl ForcedChallenges {
             | EquivocationResignStep2(role)
             | EquivocationResignNext2(role) => Some(role.clone()),
             No | Execution | Personalized(_) => None,
-            ProverForceSecondNary  => Some(ParticipantRole::Prover),
+            ProverForceSecondNary => Some(ParticipantRole::Prover),
             VerifierOutOfBoundsBits | VerifierOutOfBoundsBitsInChallenge => {
                 Some(ParticipantRole::Verifier)
             }
@@ -462,7 +462,6 @@ fn wait_msg_channel(
 }
 
 pub fn get_fail_force_config(fail_force_config: ForcedChallenges) -> ForceFailConfiguration {
-    //TODO: check all cases after refactor
     match fail_force_config {
         ForcedChallenges::InputTimeOut(name, _) => ForceFailConfiguration {
             prover_force_second_nary: false,


### PR DESCRIPTION
This PR removes multiple `unwrap`, `expect`, and `panic `calls across the codebase and replaces them with proper, explicit error handling. It improves error propagation and reporting, and reorganizes the error enum into clear, well-defined sections for better readability and maintainability.