### PR TITLE
[CI-VMX-CORD-002] Update with changes from coordinator

### DIFF
--- a/examples/union/bitcoin.rs
+++ b/examples/union/bitcoin.rs
@@ -3,7 +3,10 @@ use std::thread;
 
 use anyhow::Result;
 use bitcoin::Network;
-use bitcoind::{bitcoind::{Bitcoind, BitcoindFlags}, config::BitcoindConfig};
+use bitcoind::{
+    bitcoind::{Bitcoind, BitcoindFlags},
+    config::BitcoindConfig,
+};
 use bitvmx_bitcoin_rpc::bitcoin_client::BitcoinClient;
 use bitvmx_bitcoin_rpc::bitcoin_client::BitcoinClientApi;
 use bitvmx_client::config::Config;
@@ -89,11 +92,7 @@ pub fn stop_existing_bitcoind() -> Result<()> {
     let config = Config::new(Some("config/development.yaml".to_string()))?;
 
     // Create a temporary Bitcoind instance to check if one is running and stop it
-    let temp_bitcoind = Bitcoind::new(
-        BitcoindConfig::default(),
-        config.bitcoin,
-        None,
-    );
+    let temp_bitcoind = Bitcoind::new(BitcoindConfig::default(), config.bitcoin, None);
 
     // Attempt to stop any existing instance
     match temp_bitcoind.stop() {
@@ -131,14 +130,11 @@ pub fn prepare_bitcoin() -> Result<(BitcoinClient, Bitcoind)> {
                     block_min_tx_fee: 0.00008,
                     debug: 1,
                     fallback_fee: 0.0002,
+                    maxmempool: None,
                 }),
             )
         }
-        false => Bitcoind::new(
-            bitcoind_config,
-            config.bitcoin.clone(),
-            None
-        ),
+        false => Bitcoind::new(bitcoind_config, config.bitcoin.clone(), None),
     };
 
     bitcoind.start()?;

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -805,6 +805,20 @@ impl BitVMX {
                         max_allowed,
                     ));
                 }
+                CoordinatorNews::TransactionAlreadyInMempool(tx_id, _) => {
+                    // TODO: Complete what to do here
+                    ack_news = AckNews::Coordinator(
+                        AckCoordinatorNews::TransactionAlreadyInMempool(tx_id),
+                    );
+                }
+                CoordinatorNews::MempoolRejection(tx_id, _context_data, _counter) => {
+                    // TODO: Complete what to do here
+                    ack_news = AckNews::Coordinator(AckCoordinatorNews::MempoolRejection(tx_id));
+                }
+                CoordinatorNews::NetworkError(tx_id, _context_data, _counter) => {
+                    // TODO: Complete what to do here
+                    ack_news = AckNews::Coordinator(AckCoordinatorNews::NetworkError(tx_id));
+                }
             }
 
             self.program_context

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,7 +5,10 @@ pub mod dispute;
 
 use anyhow::Result;
 use bitcoin::{Amount, PublicKey, XOnlyPublicKey};
-use bitcoind::{bitcoind::{Bitcoind, BitcoindFlags}, config::BitcoindConfig};
+use bitcoind::{
+    bitcoind::{Bitcoind, BitcoindFlags},
+    config::BitcoindConfig,
+};
 use bitvmx_bitcoin_rpc::bitcoin_client::{BitcoinClient, BitcoinClientApi};
 use bitvmx_broker::{
     channel::channel::DualChannel,
@@ -153,6 +156,7 @@ pub fn prepare_bitcoin() -> Result<(BitcoinClient, Option<Bitcoind>, Wallet)> {
                 block_min_tx_fee: 0.00002,
                 debug: 1,
                 fallback_fee: 0.0002,
+                maxmempool: None,
             }),
         );
 

--- a/tests/independent.rs
+++ b/tests/independent.rs
@@ -19,7 +19,8 @@ use bitvmx_client::program::participant::{
 };
 use bitvmx_client::program::protocols::dispute::config::{ConfigResult, ForceFailConfiguration};
 use bitvmx_client::program::protocols::dispute::{
-    COMMITMENT, POST_COMMITMENT, PRE_COMMITMENT, action_wins, input_tx_name, program_input, program_input_prev_prefix, program_input_prev_protocol, protocol_cost
+    action_wins, input_tx_name, program_input, program_input_prev_prefix,
+    program_input_prev_protocol, protocol_cost, COMMITMENT, POST_COMMITMENT, PRE_COMMITMENT,
 };
 use bitvmx_client::program::variables::{VariableTypes, WitnessTypes};
 use bitvmx_client::types::{
@@ -357,6 +358,7 @@ impl TestHelper {
                     block_min_tx_fee: 0.00001 * MIN_TX_FEE,
                     debug: 1,
                     fallback_fee: 0.0002,
+                    maxmempool: None,
                 }),
             );
 
@@ -1437,31 +1439,46 @@ fn challenge_verifier_out_of_bounds_bits_in_challenge() -> Result<()> {
 #[ignore]
 #[test]
 fn test_input_timeout_hashes_prover() -> Result<()> {
-    test_challenge(ForcedChallenges::InputTimeOut("NARY_PROVER_1".to_string(), ParticipantRole::Prover))
+    test_challenge(ForcedChallenges::InputTimeOut(
+        "NARY_PROVER_1".to_string(),
+        ParticipantRole::Prover,
+    ))
 }
 
 #[ignore]
 #[test]
 fn test_input_timeout_pre_commitment_verifier() -> Result<()> {
-    test_challenge(ForcedChallenges::InputTimeOut(PRE_COMMITMENT.to_string(), ParticipantRole::Verifier))
+    test_challenge(ForcedChallenges::InputTimeOut(
+        PRE_COMMITMENT.to_string(),
+        ParticipantRole::Verifier,
+    ))
 }
 
 #[ignore]
 #[test]
 fn test_input_timeout_commitment_prover() -> Result<()> {
-    test_challenge(ForcedChallenges::InputTimeOut(COMMITMENT.to_string(), ParticipantRole::Prover))
+    test_challenge(ForcedChallenges::InputTimeOut(
+        COMMITMENT.to_string(),
+        ParticipantRole::Prover,
+    ))
 }
 
 #[ignore]
 #[test]
 fn test_input_timeout_post_commitment_verifier() -> Result<()> {
-    test_challenge(ForcedChallenges::InputTimeOut(POST_COMMITMENT.to_string(), ParticipantRole::Verifier))
+    test_challenge(ForcedChallenges::InputTimeOut(
+        POST_COMMITMENT.to_string(),
+        ParticipantRole::Verifier,
+    ))
 }
 
 #[ignore]
 #[test]
 fn test_input_timeout_input_prover() -> Result<()> {
-    test_challenge(ForcedChallenges::InputTimeOut(input_tx_name(0), ParticipantRole::Prover))
+    test_challenge(ForcedChallenges::InputTimeOut(
+        input_tx_name(0),
+        ParticipantRole::Prover,
+    ))
 }
 
 #[ignore]
@@ -1472,7 +1489,10 @@ fn test_input_timeout_input_prover_with_previous() -> Result<()> {
         Network::Regtest,
         Some("./verifiers/add-test-with-previous-wots.yaml".to_string()),
         Some(("00000002", 1, "00000003", 2).into()),
-        Some(ForcedChallenges::InputTimeOut(input_tx_name(2), ParticipantRole::Prover)),
+        Some(ForcedChallenges::InputTimeOut(
+            input_tx_name(2),
+            ParticipantRole::Prover,
+        )),
         None,
     )?;
     Ok(())
@@ -1486,7 +1506,10 @@ fn test_input_timeout_input_verifier() -> Result<()> {
         Network::Regtest,
         Some("../BitVMX-CPU/docker-riscv32/riscv32/build/hello-world-verifier.yaml".to_string()),
         Some(InputType::Participant("11111111".to_string(), Verifier)),
-        Some(ForcedChallenges::InputTimeOut(input_tx_name(0), ParticipantRole::Verifier)),
+        Some(ForcedChallenges::InputTimeOut(
+            input_tx_name(0),
+            ParticipantRole::Verifier,
+        )),
         None,
     )?;
     Ok(())
@@ -1500,7 +1523,10 @@ fn test_input_timeout_input_prover_cosign() -> Result<()> {
         Network::Regtest,
         Some("../BitVMX-CPU/docker-riscv32/riscv32/build/hello-world-verifier.yaml".to_string()),
         Some(InputType::Participant("11111111".to_string(), Verifier)),
-        Some(ForcedChallenges::InputTimeOut(input_tx_name(1), ParticipantRole::Prover)),
+        Some(ForcedChallenges::InputTimeOut(
+            input_tx_name(1),
+            ParticipantRole::Prover,
+        )),
         None,
     )?;
     Ok(())


### PR DESCRIPTION
This change is related with the `COINSPECT TICKET : VMX-CORD-002`

# Changes
- Update new error types coming from news. 
- Update Bitcoin flag setting with the new flag `maxmempool` created in bitcoind

IMPORTANT: 
This PR should be merge with
-  [Coordinator PR](https://github.com/FairgateLabs/rust-bitcoin-coordinator/pull/62)
- [Bitcoind PR](https://github.com/FairgateLabs/rust-bitcoind/pull/8)