### PR TITLE
Notify L2 about new block mined

### DIFF
--- a/examples/union/participants/member.rs
+++ b/examples/union/participants/member.rs
@@ -11,6 +11,7 @@ use crate::{
 use anyhow::{Error, Result};
 use bitcoin::{address::NetworkUnchecked, PublicKey, ScriptBuf, Transaction, Txid};
 use bitvmx_broker::identification::allow_list::AllowList;
+use bitvmx_client::bitvmx::SEND_NEW_BLOCK_NEWS;
 use bitvmx_client::program::protocols::union::common::get_dispute_pair_key_name;
 use bitvmx_client::{
     client::BitVMXClient,
@@ -80,6 +81,8 @@ impl Member {
             &config.testing.l2,
             allow_list,
         )?;
+
+        bitvmx.set_global_var(SEND_NEW_BLOCK_NEWS, VariableTypes::Bool(true))?;
 
         Ok(Self {
             id: id.to_string(),

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -68,6 +68,8 @@ use uuid::Uuid;
 pub const THROTTLE_TICKS: u32 = 2;
 pub const WALLET_INDEX: u32 = 100;
 pub const WALLET_CHANGE_INDEX: u32 = 101;
+pub const CLIENT_GLOBAL_SETTINGS_UUID: Uuid = Uuid::from_bytes(*b"GLOBAL_SETTINGS-");
+pub const SEND_NEW_BLOCK_NEWS: &str = "send_new_block_news";
 
 #[derive(Debug)]
 struct BitcoinUpdateState {
@@ -597,6 +599,16 @@ impl BitVMX {
                 MonitorNews::NewBlock(block_height, block_hash) => {
                     debug!("New block: {} {}", block_height, block_hash);
                     ack_news = AckNews::Monitor(AckMonitorNews::NewBlock);
+
+                    if self.send_new_block_news(&self.program_context) {
+                        let data = serde_json::to_string(&OutgoingBitVMXApiMessages::NewBlock(
+                            block_hash,
+                            block_height,
+                        ))?;
+                        self.program_context
+                            .broker_channel
+                            .send(&self.config.components.l2, data)?;
+                    }
                 }
             }
 
@@ -864,6 +876,16 @@ impl BitVMX {
         self.wallet.sync_wallet()?;
         info!("Wallet sync completed.");
         Ok(())
+    }
+
+    fn send_new_block_news(&self, context: &ProgramContext) -> bool {
+        context
+            .globals
+            .get_var(&CLIENT_GLOBAL_SETTINGS_UUID, SEND_NEW_BLOCK_NEWS)
+            .unwrap_or(None)
+            .unwrap_or(VariableTypes::Bool(false))
+            .bool()
+            .unwrap_or(false)
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bitvmx::CLIENT_GLOBAL_SETTINGS_UUID,
     config::{BrokerConfig, ComponentConfig, ComponentsConfig},
     errors::ClientError,
     program::{
@@ -274,5 +275,13 @@ impl BitVMXClient {
 
     fn serialize_key(s: &str) -> String {
         s.to_string()
+    }
+
+    pub fn set_global_var(&self, key: &str, value: VariableTypes) -> Result<()> {
+        self.send_message(IncomingBitVMXApiMessages::SetVar(
+            CLIENT_GLOBAL_SETTINGS_UUID,
+            Self::serialize_key(key),
+            value,
+        ))
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,9 @@
 use std::{rc::Rc, str::FromStr};
 
 use crate::{config::ComponentsConfig, spv_proof::BtcTxSPVProof};
-use bitcoin::{address::NetworkUnchecked, Address, PrivateKey, PublicKey, Transaction, Txid};
+use bitcoin::{
+    address::NetworkUnchecked, Address, BlockHash, PrivateKey, PublicKey, Transaction, Txid,
+};
 use bitcoin_coordinator::{coordinator::BitcoinCoordinator, TransactionStatus};
 use bitvmx_broker::{
     broker_storage::BrokerStorage,
@@ -165,6 +167,7 @@ pub enum OutgoingBitVMXApiMessages {
     WalletError(Uuid, String),
     ProtocolVisualization(Uuid, String),
     SetInput(Vec<u8>),
+    NewBlock(BlockHash, u32),
 }
 
 impl OutgoingBitVMXApiMessages {
@@ -325,6 +328,7 @@ impl OutgoingBitVMXApiMessages {
                 "ProtocolVisualization".to_string()
             }
             OutgoingBitVMXApiMessages::SetInput(_) => "SetInput".to_string(),
+            OutgoingBitVMXApiMessages::NewBlock(_, _) => "NewBlock".to_string(),
         }
     }
 }


### PR DESCRIPTION
- Add OutgoingBitVMXApiMessages::NewBlock.
- Add `CLIENT_GLOBAL_SETTINGS_UUID` for client global settings.
- Add `BitVMXClient.set_global_var` method.
- Add `SEND_NEW_BLOCK_NEWS` to control whether or not send `OutgoingBitVMXApiMessages::NewBlock` to L2.