### PR TITLE
Bitvmx contracts compatibility test prints

### DIFF
--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -60,6 +60,13 @@ mod wallet;
 pub const NETWORK: Network = Network::Regtest;
 pub const STREAM_DENOMINATION: u64 = 100_000;
 
+// Fixed pegout ID used for testing (equivalent to bytes32(uint256(1)) in Solidity)
+pub const TESTING_PEGOUT_ID: [u8; 32] = {
+    let mut id = [0u8; 32];
+    id[31] = 1;
+    id
+};
+
 static mut SLOT_INDEX_COUNTER: usize = 0;
 
 pub fn main() -> Result<()> {
@@ -383,6 +390,7 @@ pub fn cli_solidity_txs() -> Result<()> {
         &committee_agg_key,
         &dispute_keys,
         &user.public_key()?,
+        &TESTING_PEGOUT_ID,
         &request_pegin_tx,
         accept_pegin_txid,
         &named_txs,
@@ -1075,7 +1083,7 @@ pub fn advance_funds(
     should_wait: bool,
 ) -> Result<usize> {
     // This came from the contracts
-    let pegout_id = vec![0; 32]; // Placeholder for the actual peg-out ID
+    let pegout_id = TESTING_PEGOUT_ID.to_vec();
 
     // Get the selected operator's take public key (simulating what Union Client would provide)
     let operator_id = 1; // Placeholder for the actual operator ID

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -19,7 +19,7 @@ use crate::{
         master_wallet::MasterWallet,
     },
 };
-use ::bitcoin::{hashes::Hash, hex::DisplayHex, Network, OutPoint, PublicKey, Transaction, Txid};
+use ::bitcoin::{hashes::Hash, Network, OutPoint, PublicKey, Transaction, Txid};
 use anyhow::Result;
 use bitvmx_client::{
     program::{
@@ -904,76 +904,11 @@ pub fn dispatch_wt_start_enabler(committee: &Committee) -> Result<()> {
     Ok(())
 }
 
-pub fn db_print_dispute_keys(committee: &Committee) -> Result<()> {
-    // Return immediately when debug printing is disabled
-    if !crate::participants::common::DEBUG_TX {
-        return Ok(());
-    }
-
-    info!("Members Dispute/Covenant Keys (ECDSA):");
-    for (i, member) in committee.members.iter().enumerate() {
-        info!("Member {} (id: {}):", i, member.id);
-
-        if let Some(covenant_key) = member.keyring.dispute_pubkey {
-            info!(
-                "    compressed: 0x{}",
-                covenant_key.to_bytes().as_slice().to_lower_hex_string()
-            );
-        }
-        info!("  ---");
-    }
-
-    info!("Committee Aggregated Keys:");
-    info!(
-        "  - Dispute Aggregated Key (compressed): 0x{}",
-        committee
-            .public_key()?
-            .to_bytes()
-            .as_slice()
-            .to_lower_hex_string()
-    );
-    info!("");
-    info!("============================================================");
-
-    Ok(())
-}
-
-/// Print detailed accept-pegin transaction info when DEBUG_TX is enabled
-pub fn db_print_accept_pegin_tx(
-    tx: &Transaction,
-    request_pegin_txid: Txid,
-    amount: u64,
-    slot_index: usize,
-    rootstock_address: &str,
-    reimbursement_pubkey: PublicKey,
-    accept_pegin_sighash: &[u8],
-) -> Result<()> {
-    use crate::participants::common::db_print_transaction;
-
-    db_print_transaction("ACCEPT PEGIN TRANSACTION DETAILS", tx, || {
-        info!("Parameters Used:");
-        info!("  - Request Pegin TxId: 0x{}", request_pegin_txid);
-        info!("  - Request Pegin Amount: {} satoshis", amount);
-        info!("  - Slot Index: {}", slot_index);
-        info!("  - Rootstock Address: 0x{}", rootstock_address);
-        info!("  - Reimbursement Pubkey: {}", reimbursement_pubkey);
-        info!(
-            "  - Accept Pegin Sighash: 0x{}",
-            accept_pegin_sighash.to_lower_hex_string()
-        );
-        info!("");
-    });
-
-    Ok(())
-}
-
 pub fn request_pegin(committee: &Committee, user: &mut User) -> Result<(Txid, u64, Transaction)> {
     let amount: u64 = STREAM_DENOMINATION;
     let committee_public_key = committee.public_key()?;
     let dispute_keys = committee.get_dispute_keys();
     let request_pegin_timelock = committee.stream_settings.request_pegin_timelock;
-
-    db_print_dispute_keys(committee)?;
 
     let (request_pegin_txid, request_pegin_tx) = user.request_pegin(
         &committee_public_key,
@@ -1026,15 +961,6 @@ pub fn request_and_accept_pegin(
 
     let accept_pegin_txid = accept_pegin_tx.compute_txid();
 
-    db_print_accept_pegin_tx(
-        &accept_pegin_tx,
-        request_pegin_txid,
-        amount,
-        slot_index,
-        &rootstock_address,
-        reimbursement_pubkey.clone(),
-        &accept_pegin_sighash,
-    )?;
 
     info!("Accept peg-in TX dispatched. Txid: {}", accept_pegin_txid);
     print_link(NETWORK, accept_pegin_txid);

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -34,8 +34,8 @@ use bitvmx_client::{
                 types::{
                     FundsAdvanced, ACCEPT_PEGIN_TX, ADVANCE_FUNDS_TX, CANCEL_TAKE0_TX,
                     CHALLENGE_TX, INPUT_NOT_REVEALED_TX, OPERATOR_TAKE_TX, OPERATOR_WON_TX,
-                    OP_SELF_DISABLER_TX, REIMBURSEMENT_KICKOFF_TX, REVEAL_INPUT_TX,
-                    WT_SELF_DISABLER_TX,
+                    OP_SELF_DISABLER_TX, REIMBURSEMENT_KICKOFF_TX, REQUEST_PEGIN_TX,
+                    REVEAL_INPUT_TX, WT_SELF_DISABLER_TX,
                     WT_START_ENABLER_TX,
                 },
             },
@@ -330,13 +330,12 @@ pub fn cli_solidity_txs() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, accept_pegin_tx, request_pegin_tx) =
+    let (slot_index, _, _, request_pegin_tx) =
         request_and_accept_pegin(&mut committee, &mut user)?;
     let op_index = advance_funds(&mut committee, user.public_key()?, slot_index, false)?;
 
     let committee_agg_key = committee.public_key()?;
     let dispute_keys = committee.get_dispute_keys();
-    let accept_pegin_txid = accept_pegin_tx.compute_txid();
 
     let committee_id = committee.committee_id();
     let accept_pegin_pid = get_accept_pegin_pid(committee_id, slot_index);
@@ -354,6 +353,7 @@ pub fn cli_solidity_txs() -> Result<()> {
     let input_not_revealed_name = indexed_name(INPUT_NOT_REVEALED_TX, slot_index);
 
     let named_txs: Vec<(&str, Transaction)> = vec![
+        (REQUEST_PEGIN_TX, request_pegin_tx),
         (
             ADVANCE_FUNDS_TX,
             get_transaction(&committee.members[op_index], advance_funds_pid, ADVANCE_FUNDS_TX)?,
@@ -401,8 +401,6 @@ pub fn cli_solidity_txs() -> Result<()> {
         &dispute_keys,
         &user.public_key()?,
         &TESTING_PEGOUT_ID,
-        &request_pegin_tx,
-        accept_pegin_txid,
         &named_txs,
     );
 

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -2,7 +2,10 @@ use crate::{
     bitcoin::{BitcoinWrapper, HIGH_FEE_NODE_ENABLED},
     participants::{
         committee::Committee,
-        common::{calculate_taproot_key_path_sighash, get_user_take_tx, PEGIN_CONFIRMATIONS},
+        common::{
+            calculate_taproot_key_path_sighash, format_transaction_solidity, get_user_take_tx,
+            PEGIN_CONFIRMATIONS,
+        },
         member::Member,
         user::User,
     },
@@ -25,12 +28,14 @@ use bitvmx_client::{
             dispute::program_input,
             union::{
                 common::{
-                    get_accept_pegin_pid, get_dispute_channel_pid, get_dispute_core_pid,
-                    indexed_name,
+                    get_accept_pegin_pid, get_advance_funds_pid, get_dispute_channel_pid,
+                    get_dispute_core_pid, indexed_name,
                 },
                 types::{
-                    FundsAdvanced, ACCEPT_PEGIN_TX, CANCEL_TAKE0_TX, OP_SELF_DISABLER_TX,
-                    WT_SELF_DISABLER_TX, WT_START_ENABLER_TX,
+                    FundsAdvanced, ACCEPT_PEGIN_TX, ADVANCE_FUNDS_TX, CANCEL_TAKE0_TX,
+                    CHALLENGE_TX, OPERATOR_TAKE_TX, OPERATOR_WON_TX, OP_SELF_DISABLER_TX,
+                    REIMBURSEMENT_KICKOFF_TX, REVEAL_INPUT_TX, WT_SELF_DISABLER_TX,
+                    WT_START_ENABLER_TX,
                 },
             },
         },
@@ -91,6 +96,7 @@ pub fn main() -> Result<()> {
         Some("members_recover_funds") => cli_members_recover_funds()?,
         Some("user_recover_funds") => cli_user_recover_funds()?,
         Some("wallet_recover_funds") => cli_wallet_recover_funds()?,
+        Some("solidity_txs") => cli_solidity_txs()?,
         Some(cmd) => {
             eprintln!("Unknown command: {}", cmd);
             print_usage();
@@ -194,6 +200,7 @@ fn print_usage() {
         "wallet_recover_funds",
         "Send master wallet funds to address",
     );
+    print_cmd_help("print_txs", "Print protocol TXs to create contracts tests");
 }
 
 fn cli_create_wallet(network: Option<&String>) -> Result<()> {
@@ -307,6 +314,79 @@ pub fn cli_advance_funds_twice() -> Result<()> {
     advance_funds(&mut committee, user.public_key()?, slot_index, true)?;
 
     Ok(())
+}
+
+pub fn cli_solidity_txs() -> Result<()> {
+    if HIGH_FEE_NODE_ENABLED {
+        info!("This example run faster with a client node with low fees. You can disable it setting HIGH_FEE_NODE_ENABLED to false.");
+    }
+
+    let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
+    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let op_index = advance_funds(&mut committee, user.public_key()?, slot_index, false)?;
+    let operator = &committee.members[op_index];
+
+    let committee_id = committee.committee_id();
+    let accept_pegin_pid = get_accept_pegin_pid(committee_id, slot_index);
+    let dispute_core_pid =
+        get_dispute_core_pid(committee_id, &operator.keyring.take_pubkey.unwrap());
+    let advance_funds_pid = get_advance_funds_pid(committee_id, slot_index);
+
+    // Advance funds transaction
+    get_and_print_transaction(operator, advance_funds_pid, ADVANCE_FUNDS_TX)?;
+
+    // Accept pegin protocol transactions
+    get_and_print_transaction(operator, accept_pegin_pid, ACCEPT_PEGIN_TX)?;
+    get_and_print_transaction(
+        operator,
+        accept_pegin_pid,
+        &indexed_name(OPERATOR_TAKE_TX, op_index),
+    )?;
+    get_and_print_transaction(
+        operator,
+        accept_pegin_pid,
+        &indexed_name(OPERATOR_WON_TX, op_index),
+    )?;
+
+    // Dispute core protocol transactions
+    get_and_print_transaction(
+        operator,
+        dispute_core_pid,
+        &indexed_name(REIMBURSEMENT_KICKOFF_TX, slot_index),
+    )?;
+    get_and_print_transaction(
+        &committee.members[op_index + 1],
+        dispute_core_pid,
+        &indexed_name(CHALLENGE_TX, slot_index),
+    )?;
+    get_and_print_transaction(
+        operator,
+        dispute_core_pid,
+        &indexed_name(REVEAL_INPUT_TX, slot_index),
+    )?;
+
+    Ok(())
+}
+
+fn get_and_print_transaction(
+    member: &Member,
+    protocol_id: Uuid,
+    tx_name: &str,
+) -> Result<Transaction> {
+    info!("Requesting TX: {}. Protocol ID: {}", tx_name, protocol_id);
+    member
+        .bitvmx
+        .get_transaction_by_name(protocol_id, tx_name.to_string())?;
+    thread::sleep(std::time::Duration::from_millis(200));
+    let tx = wait_until_msg!(&member.bitvmx, OutgoingBitVMXApiMessages::TransactionInfo(_, _, _tx) => _tx);
+
+    info!("==========================================");
+    info!("Transaction name: {}", tx_name);
+    info!("Solidity Format:");
+    info!("\n\n{}\n\n", format_transaction_solidity(&tx));
+    info!("==========================================");
+
+    Ok(tx)
 }
 
 pub fn cli_challenge(winner: Option<&String>) -> Result<()> {
@@ -1042,8 +1122,6 @@ fn challenge(
     // Force member 0 to dispatch reimbursement without proper advancement setup
     let committee_id = committee.committee_id();
     let members_len = committee.members.len();
-    // let operator: &mut Member = &mut committee.members[operator_index];
-    let uuid = Uuid::new_v4();
 
     let operator_pubkey = committee.members[operator_index]
         .keyring
@@ -1064,7 +1142,6 @@ fn challenge(
 
     // This operator is the one that will be challenged. So make advance funds with "correct" data.
     committee.members[operator_index].advance_funds(
-        Uuid::new_v4(),
         committee_id,
         slot_index,
         user_pubkey,
@@ -1099,7 +1176,6 @@ fn challenge(
 
         // A wrong slot here, would be equivalent to a false trigger operator take
         committee.members[index].advance_funds(
-            uuid,
             committee_id,
             slot,
             user_pubkey.clone(),

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -336,6 +336,8 @@ pub fn cli_solidity_txs() -> Result<()> {
 
     let committee_agg_key = committee.public_key()?;
     let dispute_keys = committee.get_dispute_keys();
+    let operator_count = committee.members.iter().filter(|m| m.role == ParticipantRole::Prover).count();
+    let watchtower_count = committee.members.iter().filter(|m| m.role == ParticipantRole::Verifier).count();
 
     let committee_id = committee.committee_id();
     let accept_pegin_pid = get_accept_pegin_pid(committee_id, slot_index);
@@ -396,12 +398,28 @@ pub fn cli_solidity_txs() -> Result<()> {
         ),
     ];
 
+    let export_txids = [
+        REQUEST_PEGIN_TX,
+        // ADVANCE_FUNDS_TX,
+        ACCEPT_PEGIN_TX,
+        // &op_take_name,
+        // &op_won_name,
+        &reimb_name,
+        &challenge_name,
+        &reveal_name,
+        // &input_not_revealed_name,
+    ];
+
     let solidity_file = format_solidity_data_file(
         &committee_agg_key,
         &dispute_keys,
         &user.public_key()?,
         &TESTING_PEGOUT_ID,
+        op_index,
+        operator_count,
+        watchtower_count,
         &named_txs,
+        &export_txids,
     );
 
     let output_path = match std::env::var("EXAMPLE_LOG_DIR") {

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -3,7 +3,7 @@ use crate::{
     participants::{
         committee::Committee,
         common::{
-            calculate_taproot_key_path_sighash, format_transaction_solidity, get_user_take_tx,
+            calculate_taproot_key_path_sighash, format_solidity_data_file, get_user_take_tx,
             PEGIN_CONFIRMATIONS,
         },
         member::Member,
@@ -246,7 +246,7 @@ pub fn cli_request_pegin() -> Result<()> {
 pub fn cli_reject_pegin() -> Result<()> {
     let (committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
 
-    let (txid, _) = request_pegin(&committee, &mut user)?;
+    let (txid, _, _) = request_pegin(&committee, &mut user)?;
 
     let member_index = 1;
     committee.members[member_index].reject_pegin(committee.committee_id(), txid, member_index)?;
@@ -267,7 +267,7 @@ pub fn cli_accept_pegin() -> Result<()> {
 pub fn cli_cancel_take0() -> Result<()> {
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
 
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
     thread::sleep(Duration::from_secs(1));
 
     wait_for_blocks(&committee.bitcoin_client, get_blocks_to_wait())?;
@@ -296,7 +296,7 @@ pub fn cli_request_pegout() -> Result<()> {
 
 pub fn cli_advance_funds() -> Result<()> {
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     advance_funds(&mut committee, user.public_key()?, slot_index, true)?;
     Ok(())
@@ -306,11 +306,11 @@ pub fn cli_advance_funds_twice() -> Result<()> {
     let (mut committee, mut user, _) = pegin_setup(2, NETWORK == Network::Regtest)?;
 
     // First advance should use funding UTXO
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
     advance_funds(&mut committee, user.public_key()?, slot_index, true)?;
 
     // Second advance should use change UTXO and Operator Take UTXO
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
     advance_funds(&mut committee, user.public_key()?, slot_index, true)?;
 
     Ok(())
@@ -322,70 +322,87 @@ pub fn cli_solidity_txs() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, accept_pegin_tx, request_pegin_tx) =
+        request_and_accept_pegin(&mut committee, &mut user)?;
     let op_index = advance_funds(&mut committee, user.public_key()?, slot_index, false)?;
-    let operator = &committee.members[op_index];
+
+    let committee_agg_key = committee.public_key()?;
+    let dispute_keys = committee.get_dispute_keys();
+    let accept_pegin_txid = accept_pegin_tx.compute_txid();
 
     let committee_id = committee.committee_id();
     let accept_pegin_pid = get_accept_pegin_pid(committee_id, slot_index);
-    let dispute_core_pid =
-        get_dispute_core_pid(committee_id, &operator.keyring.take_pubkey.unwrap());
+    let dispute_core_pid = get_dispute_core_pid(
+        committee_id,
+        &committee.members[op_index].keyring.take_pubkey.unwrap(),
+    );
     let advance_funds_pid = get_advance_funds_pid(committee_id, slot_index);
 
-    // Advance funds transaction
-    get_and_print_transaction(operator, advance_funds_pid, ADVANCE_FUNDS_TX)?;
+    let op_take_name = indexed_name(OPERATOR_TAKE_TX, op_index);
+    let op_won_name = indexed_name(OPERATOR_WON_TX, op_index);
+    let reimb_name = indexed_name(REIMBURSEMENT_KICKOFF_TX, slot_index);
+    let challenge_name = indexed_name(CHALLENGE_TX, slot_index);
+    let reveal_name = indexed_name(REVEAL_INPUT_TX, slot_index);
 
-    // Accept pegin protocol transactions
-    get_and_print_transaction(operator, accept_pegin_pid, ACCEPT_PEGIN_TX)?;
-    get_and_print_transaction(
-        operator,
-        accept_pegin_pid,
-        &indexed_name(OPERATOR_TAKE_TX, op_index),
-    )?;
-    get_and_print_transaction(
-        operator,
-        accept_pegin_pid,
-        &indexed_name(OPERATOR_WON_TX, op_index),
-    )?;
+    let named_txs: Vec<(&str, Transaction)> = vec![
+        (
+            ADVANCE_FUNDS_TX,
+            get_transaction(&committee.members[op_index], advance_funds_pid, ADVANCE_FUNDS_TX)?,
+        ),
+        (
+            ACCEPT_PEGIN_TX,
+            get_transaction(&committee.members[op_index], accept_pegin_pid, ACCEPT_PEGIN_TX)?,
+        ),
+        (
+            &op_take_name,
+            get_transaction(&committee.members[op_index], accept_pegin_pid, &op_take_name)?,
+        ),
+        (
+            &op_won_name,
+            get_transaction(&committee.members[op_index], accept_pegin_pid, &op_won_name)?,
+        ),
+        (
+            &reimb_name,
+            get_transaction(&committee.members[op_index], dispute_core_pid, &reimb_name)?,
+        ),
+        (
+            &challenge_name,
+            get_transaction(
+                &committee.members[op_index + 1],
+                dispute_core_pid,
+                &challenge_name,
+            )?,
+        ),
+        (
+            &reveal_name,
+            get_transaction(&committee.members[op_index], dispute_core_pid, &reveal_name)?,
+        ),
+    ];
 
-    // Dispute core protocol transactions
-    get_and_print_transaction(
-        operator,
-        dispute_core_pid,
-        &indexed_name(REIMBURSEMENT_KICKOFF_TX, slot_index),
-    )?;
-    get_and_print_transaction(
-        &committee.members[op_index + 1],
-        dispute_core_pid,
-        &indexed_name(CHALLENGE_TX, slot_index),
-    )?;
-    get_and_print_transaction(
-        operator,
-        dispute_core_pid,
-        &indexed_name(REVEAL_INPUT_TX, slot_index),
-    )?;
+    let solidity_file = format_solidity_data_file(
+        &committee_agg_key,
+        &dispute_keys,
+        &request_pegin_tx,
+        accept_pegin_txid,
+        &named_txs,
+    );
 
+    let output_path = match std::env::var("EXAMPLE_LOG_DIR") {
+        Ok(log_dir) => std::path::PathBuf::from(log_dir).join("BitVMXCompatibilityData.sol"),
+        Err(_) => std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../BitVMXCompatibilityData.sol"),
+    };
+    std::fs::write(&output_path, &solidity_file)?;
+    info!("Written to: {}", output_path.display());
     Ok(())
 }
 
-fn get_and_print_transaction(
-    member: &Member,
-    protocol_id: Uuid,
-    tx_name: &str,
-) -> Result<Transaction> {
-    info!("Requesting TX: {}. Protocol ID: {}", tx_name, protocol_id);
+fn get_transaction(member: &Member, protocol_id: Uuid, tx_name: &str) -> Result<Transaction> {
     member
         .bitvmx
         .get_transaction_by_name(protocol_id, tx_name.to_string())?;
     thread::sleep(std::time::Duration::from_millis(200));
     let tx = wait_until_msg!(&member.bitvmx, OutgoingBitVMXApiMessages::TransactionInfo(_, _, _tx) => _tx);
-
-    info!("==========================================");
-    info!("Transaction name: {}", tx_name);
-    info!("Solidity Format:");
-    info!("\n\n{}\n\n", format_transaction_solidity(&tx));
-    info!("==========================================");
-
     Ok(tx)
 }
 
@@ -406,7 +423,7 @@ pub fn cli_challenge(winner: Option<&String>) -> Result<()> {
     };
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     let op_index = 1;
     challenge(
@@ -447,7 +464,7 @@ pub fn cli_challenge_reason(input: Option<&String>) -> Result<()> {
     info!("Starting challenge with reason: {:?}", challenge_reason);
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     let op_index = 1;
     challenge(
@@ -469,7 +486,7 @@ pub fn cli_wt_disabler() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(2, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     // First challenge where WT are penalized. Operator 0 wins.
     let op_index = 0;
@@ -492,7 +509,7 @@ pub fn cli_wt_disabler() -> Result<()> {
         get_blocks_to_wait() + additional_blocks as u32,
     )?;
 
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     // Now Operator 1 is challenged
     // In this second challenge WTs are already penalized. WT_DISABLERs should be dispatched.
@@ -517,7 +534,7 @@ pub fn cli_op_no_cosign() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     let op_index = 1;
     challenge(
@@ -552,7 +569,7 @@ pub fn cli_wt_no_challenge() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
     let op_index = 1;
 
     challenge(
@@ -593,7 +610,7 @@ pub fn cli_input_not_revealed() -> Result<()> {
     }
 
     let (mut committee, mut user, _) = pegin_setup(1, NETWORK == Network::Regtest)?;
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
     wait_for_blocks(&committee.bitcoin_client, get_blocks_to_wait())?;
 
     let op_index = 1;
@@ -673,8 +690,8 @@ pub fn cli_double_challenge() -> Result<()> {
     let (mut committee, mut user, _) = pegin_setup(2, NETWORK == Network::Regtest)?;
 
     // Accept 2 pegins to have 2 operator take TXs to dispatch
-    let (slot_index, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
-    (_, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    let (slot_index, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
+    (_, _, _, _) = request_and_accept_pegin(&mut committee, &mut user)?;
 
     let operator_id = 1;
     // Dispatch first reimbusement without advancing funds.
@@ -915,7 +932,7 @@ pub fn db_print_accept_pegin_tx(
     Ok(())
 }
 
-pub fn request_pegin(committee: &Committee, user: &mut User) -> Result<(Txid, u64)> {
+pub fn request_pegin(committee: &Committee, user: &mut User) -> Result<(Txid, u64, Transaction)> {
     let amount: u64 = STREAM_DENOMINATION;
     let committee_public_key = committee.public_key()?;
     let dispute_keys = committee.get_dispute_keys();
@@ -923,7 +940,7 @@ pub fn request_pegin(committee: &Committee, user: &mut User) -> Result<(Txid, u6
 
     db_print_dispute_keys(committee)?;
 
-    let request_pegin_txid = user.request_pegin(
+    let (request_pegin_txid, request_pegin_tx) = user.request_pegin(
         &committee_public_key,
         amount,
         dispute_keys.as_slice(),
@@ -941,14 +958,14 @@ pub fn request_pegin(committee: &Committee, user: &mut User) -> Result<(Txid, u6
 
     info!("Request pegin completed.");
     confirm_to_continue();
-    Ok((request_pegin_txid, amount))
+    Ok((request_pegin_txid, amount, request_pegin_tx))
 }
 
 pub fn request_and_accept_pegin(
     committee: &mut Committee,
     user: &mut User,
-) -> Result<(usize, u64, Transaction)> {
-    let (request_pegin_txid, amount) = request_pegin(committee, user)?;
+) -> Result<(usize, u64, Transaction, Transaction)> {
+    let (request_pegin_txid, amount, request_pegin_tx) = request_pegin(committee, user)?;
 
     // This came from the contracts
     let rootstock_address = user.get_rsk_address();
@@ -1002,12 +1019,12 @@ pub fn request_and_accept_pegin(
 
     info!("Pegin accepted and confirmed.");
     confirm_to_continue();
-    Ok((slot_index, amount, accept_pegin_tx))
+    Ok((slot_index, amount, accept_pegin_tx, request_pegin_tx))
 }
 
 pub fn request_pegout() -> Result<()> {
     let (mut committee, mut user, _) = pegin_setup(1, true)?;
-    let (slot_index, stream_value, accept_pegin_tx) =
+    let (slot_index, stream_value, accept_pegin_tx, _) =
         request_and_accept_pegin(&mut committee, &mut user)?;
 
     let user_pubkey = user.public_key()?;

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -33,8 +33,9 @@ use bitvmx_client::{
                 },
                 types::{
                     FundsAdvanced, ACCEPT_PEGIN_TX, ADVANCE_FUNDS_TX, CANCEL_TAKE0_TX,
-                    CHALLENGE_TX, OPERATOR_TAKE_TX, OPERATOR_WON_TX, OP_SELF_DISABLER_TX,
-                    REIMBURSEMENT_KICKOFF_TX, REVEAL_INPUT_TX, WT_SELF_DISABLER_TX,
+                    CHALLENGE_TX, INPUT_NOT_REVEALED_TX, OPERATOR_TAKE_TX, OPERATOR_WON_TX,
+                    OP_SELF_DISABLER_TX, REIMBURSEMENT_KICKOFF_TX, REVEAL_INPUT_TX,
+                    WT_SELF_DISABLER_TX,
                     WT_START_ENABLER_TX,
                 },
             },
@@ -350,6 +351,7 @@ pub fn cli_solidity_txs() -> Result<()> {
     let reimb_name = indexed_name(REIMBURSEMENT_KICKOFF_TX, slot_index);
     let challenge_name = indexed_name(CHALLENGE_TX, slot_index);
     let reveal_name = indexed_name(REVEAL_INPUT_TX, slot_index);
+    let input_not_revealed_name = indexed_name(INPUT_NOT_REVEALED_TX, slot_index);
 
     let named_txs: Vec<(&str, Transaction)> = vec![
         (
@@ -383,6 +385,14 @@ pub fn cli_solidity_txs() -> Result<()> {
         (
             &reveal_name,
             get_transaction(&committee.members[op_index], dispute_core_pid, &reveal_name)?,
+        ),
+        (
+            &input_not_revealed_name,
+            get_transaction(
+                &committee.members[op_index + 1],
+                dispute_core_pid,
+                &input_not_revealed_name,
+            )?,
         ),
     ];
 

--- a/examples/union/main.rs
+++ b/examples/union/main.rs
@@ -382,6 +382,7 @@ pub fn cli_solidity_txs() -> Result<()> {
     let solidity_file = format_solidity_data_file(
         &committee_agg_key,
         &dispute_keys,
+        &user.public_key()?,
         &request_pegin_tx,
         accept_pegin_txid,
         &named_txs,

--- a/examples/union/participants/committee.rs
+++ b/examples/union/participants/committee.rs
@@ -272,12 +272,10 @@ impl Committee {
         selected_operator_pubkey: PublicKey,
         fee: u64,
     ) -> Result<()> {
-        let protocol_id = Uuid::new_v4();
         let committee_id = self.committee_id.clone();
 
         self.all(|op: &mut Member| {
             op.advance_funds(
-                protocol_id,
                 committee_id,
                 slot_id,
                 user_public_key,

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -11,72 +11,8 @@ use bitcoin::{
 use bitvmx_client::program::protocols::union::types::{
     StreamSettings, UnionSettings, P2TR_FEE, SPEEDUP_VALUE, USER_TAKE_FEE,
 };
-use tracing::info;
-
-pub const DEBUG_TX: bool = false;
 pub const PEGIN_CONFIRMATIONS: u16 = 6; // This value should be get from the contract
 pub const PEGOUT_CONFIRMATIONS: u16 = 6; // This value should be get from the contract
-
-/// Generic transaction debug printer that can be used for any transaction type
-pub fn db_print_transaction<F>(title: &str, tx: &Transaction, print_params: F)
-where
-    F: FnOnce(),
-{
-    if !DEBUG_TX {
-        return;
-    }
-
-    info!("=== {} ===", title);
-
-    // Print transaction-specific parameters using the closure
-    print_params();
-
-    info!("Transaction Structure:");
-    info!("  - Version: {}", tx.version.0);
-    info!("  - Number of Inputs: {}", tx.input.len());
-    info!("  - Number of Outputs: {}", tx.output.len());
-    info!("  - Locktime: {}", tx.lock_time);
-    info!("");
-    info!("Transaction Details:");
-    info!("  - TxId: 0x{}", tx.compute_txid());
-    info!("");
-
-    // Log each input
-    for (i, input) in tx.input.iter().enumerate() {
-        info!("Input {}:", i);
-        info!("  - Previous TxId: 0x{}", input.previous_output.txid);
-        info!("  - Previous Vout: {}", input.previous_output.vout);
-        info!(
-            "  - ScriptSig: {}",
-            input.script_sig.as_bytes().to_lower_hex_string()
-        );
-        info!(
-            "  - Sequence: 0x{:08X} ({})",
-            input.sequence.0, input.sequence.0
-        );
-        info!("  - Witness items: {}", input.witness.len());
-        for (j, witness_item) in input.witness.iter().enumerate() {
-            info!("    Witness {}: {}", j, witness_item.to_lower_hex_string());
-        }
-    }
-    info!("");
-
-    // Log each output
-    for (i, output) in tx.output.iter().enumerate() {
-        info!("Output {}:", i);
-        info!("  - Value: {} satoshis", output.value.to_sat());
-        info!(
-            "  - ScriptPubKey: {}",
-            output.script_pubkey.as_bytes().to_lower_hex_string()
-        );
-    }
-    info!("");
-
-    info!("Solidity Transaction Format:");
-    info!("{}", format_transaction_solidity(tx));
-    info!("==========================================");
-    info!("");
-}
 
 /// Format a Bitcoin transaction in Solidity syntax for cross-system verification
 pub fn format_transaction_solidity(tx: &Transaction) -> String {
@@ -358,9 +294,6 @@ pub fn calculate_taproot_key_path_sighash(
     input_index: usize,
     prevouts: &[TxOut],
 ) -> Result<[u8; 32], TaprootError> {
-    info!("TX: {:?}", tx);
-    info!("Prevouts: {:?}", prevouts);
-
     let mut sighash_cache = SighashCache::new(tx);
     let prevouts = Prevouts::All(prevouts);
 

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -120,13 +120,20 @@ pub fn format_transaction_solidity(tx: &Transaction) -> String {
 
     // Assign each output
     for (i, out) in tx.output.iter().enumerate() {
-        output.push_str(&format!("        outputs[{}] = BtcTxOut({{\n", i));
-        output.push_str(&format!("            amount: {},\n", out.value.to_sat()));
-        output.push_str(&format!(
-            "            scriptPubKey: hex\"{}\"\n",
-            out.script_pubkey.as_bytes().to_lower_hex_string()
-        ));
-        output.push_str("        });\n");
+        let amount = out.value.to_sat();
+        let script_hex = out.script_pubkey.as_bytes().to_lower_hex_string();
+        let single = format!(
+            "        outputs[{}] = BtcTxOut({{amount: {}, scriptPubKey: hex\"{}\"}});\n",
+            i, amount, script_hex
+        );
+        if single.len() - 1 <= 120 {
+            output.push_str(&single);
+        } else {
+            output.push_str(&format!("        outputs[{}] = BtcTxOut({{\n", i));
+            output.push_str(&format!("            amount: {},\n", amount));
+            output.push_str(&format!("            scriptPubKey: hex\"{}\"\n", script_hex));
+            output.push_str("        });\n");
+        }
         if i < tx.output.len() - 1 {
             output.push_str("\n");
         }
@@ -176,6 +183,24 @@ fn tx_name_to_fn_name(tx_name: &str) -> String {
     format!("_getBitVMX{}Tx", pascal)
 }
 
+fn format_bytes_constant(name: &str, value: &str) -> String {
+    let single = format!("    bytes constant {} = {};", name, value);
+    if single.len() <= 120 {
+        format!("{}\n", single)
+    } else {
+        format!("    bytes constant {} =\n        {};\n", name, value)
+    }
+}
+
+fn format_bytes32_constant(name: &str, value: &str) -> String {
+    let single = format!("    bytes32 constant {} = {};", name, value);
+    if single.len() <= 120 {
+        format!("{}\n", single)
+    } else {
+        format!("    bytes32 constant {} =\n        {};\n", name, value)
+    }
+}
+
 pub fn format_solidity_data_file(
     committee_agg_key: &PublicKey,
     dispute_keys: &[PublicKey],
@@ -210,20 +235,14 @@ pub fn format_solidity_data_file(
         .to_bytes()
         .as_slice()
         .to_lower_hex_string();
-    s.push_str("    bytes constant COMMITTEE_AGGREGATED_KEY =\n");
-    s.push_str(&format!("        hex\"{}\";\n", key_hex));
+    s.push_str(&format_bytes_constant("COMMITTEE_AGGREGATED_KEY", &format!("hex\"{}\"", key_hex)));
     s.push_str("\n");
 
     let user_key_hex = user_pubkey.to_bytes().as_slice().to_lower_hex_string();
-    s.push_str("    bytes constant USER_COMPRESSED_PUBKEY =\n");
-    s.push_str(&format!("        hex\"{}\";\n", user_key_hex));
+    s.push_str(&format_bytes_constant("USER_COMPRESSED_PUBKEY", &format!("hex\"{}\"", user_key_hex)));
     s.push_str("\n");
 
-    s.push_str("    bytes32 constant PEGOUT_ID =\n");
-    s.push_str(&format!(
-        "        0x{};\n",
-        pegout_id.as_slice().to_lower_hex_string()
-    ));
+    s.push_str(&format_bytes32_constant("PEGOUT_ID", &format!("0x{}", pegout_id.as_slice().to_lower_hex_string())));
     s.push_str("\n");
 
     s.push_str(&format!("    uint256 constant OPERATOR_INDEX = {};\n", op_index));
@@ -234,8 +253,7 @@ pub fn format_solidity_data_file(
     for (name, tx) in named_transactions {
         if export_txids.contains(name) {
             let const_name = tx_name_to_const_name(name);
-            s.push_str(&format!("    bytes32 constant {} =\n", const_name));
-            s.push_str(&format!("        0x{};\n", tx.compute_txid()));
+            s.push_str(&format_bytes32_constant(&const_name, &format!("0x{}", tx.compute_txid())));
             s.push_str("\n");
         }
     }
@@ -252,7 +270,7 @@ pub fn format_solidity_data_file(
         let parity = bytes[0];
         let x_only = &bytes[1..];
         s.push_str(&format!(
-            "        keys[{}] = CompactPubKey({{parity: 0x{:02x}, xOnly: 0x{}}});\n",
+            "        keys[{}] =\n            CompactPubKey({{parity: 0x{:02x}, xOnly: 0x{}}});\n",
             i,
             parity,
             x_only.to_lower_hex_string()
@@ -261,7 +279,7 @@ pub fn format_solidity_data_file(
     s.push_str("    }\n");
     s.push_str("\n");
 
-    for (name, tx) in named_transactions {
+    for (i, (name, tx)) in named_transactions.iter().enumerate() {
         let fn_name = tx_name_to_fn_name(name);
         s.push_str(&format!(
             "    function {}() internal pure returns (BtcTransaction memory) {{\n",
@@ -269,7 +287,9 @@ pub fn format_solidity_data_file(
         ));
         s.push_str(&format_transaction_solidity(tx));
         s.push_str("\n    }\n");
-        s.push_str("\n");
+        if i < named_transactions.len() - 1 {
+            s.push_str("\n");
+        }
     }
 
     s.push_str("}\n");

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -171,6 +171,7 @@ pub fn format_solidity_data_file(
     committee_agg_key: &PublicKey,
     dispute_keys: &[PublicKey],
     user_pubkey: &PublicKey,
+    pegout_id: &[u8; 32],
     request_pegin_tx: &Transaction,
     accept_pegin_txid: Txid,
     named_transactions: &[(&str, Transaction)],
@@ -209,6 +210,13 @@ pub fn format_solidity_data_file(
     let user_key_hex = user_pubkey.to_bytes().as_slice().to_lower_hex_string();
     s.push_str("    bytes constant USER_COMPRESSED_PUBKEY =\n");
     s.push_str(&format!("        hex\"{}\";\n", user_key_hex));
+    s.push_str("\n");
+
+    s.push_str("    bytes32 constant PEGOUT_ID =\n");
+    s.push_str(&format!(
+        "        0x{};\n",
+        pegout_id.as_slice().to_lower_hex_string()
+    ));
     s.push_str("\n");
 
     s.push_str(

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -181,7 +181,11 @@ pub fn format_solidity_data_file(
     dispute_keys: &[PublicKey],
     user_pubkey: &PublicKey,
     pegout_id: &[u8; 32],
+    op_index: usize,
+    operator_count: usize,
+    watchtower_count: usize,
     named_transactions: &[(&str, Transaction)],
+    export_txids: &[&str],
 ) -> String {
     let mut s = String::new();
 
@@ -222,11 +226,18 @@ pub fn format_solidity_data_file(
     ));
     s.push_str("\n");
 
+    s.push_str(&format!("    uint256 constant OPERATOR_INDEX = {};\n", op_index));
+    s.push_str(&format!("    uint8 constant OPERATOR_COUNT = {};\n", operator_count));
+    s.push_str(&format!("    uint8 constant WATCHTOWER_COUNT = {};\n", watchtower_count));
+    s.push_str("\n");
+
     for (name, tx) in named_transactions {
-        let const_name = tx_name_to_const_name(name);
-        s.push_str(&format!("    bytes32 constant {} =\n", const_name));
-        s.push_str(&format!("        0x{};\n", tx.compute_txid()));
-        s.push_str("\n");
+        if export_txids.contains(name) {
+            let const_name = tx_name_to_const_name(name);
+            s.push_str(&format!("    bytes32 constant {} =\n", const_name));
+            s.push_str(&format!("        0x{};\n", tx.compute_txid()));
+            s.push_str("\n");
+        }
     }
 
     s.push_str(

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -144,6 +144,15 @@ pub fn format_transaction_solidity(tx: &Transaction) -> String {
     output
 }
 
+fn tx_name_to_const_name(tx_name: &str) -> String {
+    let base = if let Some(pos) = tx_name.find("_TX") {
+        &tx_name[..pos]
+    } else {
+        tx_name
+    };
+    format!("EXPECTED_{}_TXID", base)
+}
+
 fn tx_name_to_fn_name(tx_name: &str) -> String {
     let base = if let Some(pos) = tx_name.find("_TX") {
         &tx_name[..pos]
@@ -172,8 +181,6 @@ pub fn format_solidity_data_file(
     dispute_keys: &[PublicKey],
     user_pubkey: &PublicKey,
     pegout_id: &[u8; 32],
-    request_pegin_tx: &Transaction,
-    accept_pegin_txid: Txid,
     named_transactions: &[(&str, Transaction)],
 ) -> String {
     let mut s = String::new();
@@ -203,10 +210,6 @@ pub fn format_solidity_data_file(
     s.push_str(&format!("        hex\"{}\";\n", key_hex));
     s.push_str("\n");
 
-    s.push_str("    bytes32 constant EXPECTED_ACCEPT_PEGIN_TXID =\n");
-    s.push_str(&format!("        0x{};\n", accept_pegin_txid));
-    s.push_str("\n");
-
     let user_key_hex = user_pubkey.to_bytes().as_slice().to_lower_hex_string();
     s.push_str("    bytes constant USER_COMPRESSED_PUBKEY =\n");
     s.push_str(&format!("        hex\"{}\";\n", user_key_hex));
@@ -218,6 +221,13 @@ pub fn format_solidity_data_file(
         pegout_id.as_slice().to_lower_hex_string()
     ));
     s.push_str("\n");
+
+    for (name, tx) in named_transactions {
+        let const_name = tx_name_to_const_name(name);
+        s.push_str(&format!("    bytes32 constant {} =\n", const_name));
+        s.push_str(&format!("        0x{};\n", tx.compute_txid()));
+        s.push_str("\n");
+    }
 
     s.push_str(
         "    function _getBitVMXDisputeKeys() internal pure returns (CompactPubKey[] memory keys) {\n",
@@ -238,11 +248,6 @@ pub fn format_solidity_data_file(
         ));
     }
     s.push_str("    }\n");
-    s.push_str("\n");
-
-    s.push_str("    function _getBitVMXRequestPeginTransaction() internal pure returns (BtcTransaction memory) {\n");
-    s.push_str(&format_transaction_solidity(request_pegin_tx));
-    s.push_str("\n    }\n");
     s.push_str("\n");
 
     for (name, tx) in named_transactions {

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -170,6 +170,7 @@ fn tx_name_to_fn_name(tx_name: &str) -> String {
 pub fn format_solidity_data_file(
     committee_agg_key: &PublicKey,
     dispute_keys: &[PublicKey],
+    user_pubkey: &PublicKey,
     request_pegin_tx: &Transaction,
     accept_pegin_txid: Txid,
     named_transactions: &[(&str, Transaction)],
@@ -203,6 +204,11 @@ pub fn format_solidity_data_file(
 
     s.push_str("    bytes32 constant EXPECTED_ACCEPT_PEGIN_TXID =\n");
     s.push_str(&format!("        0x{};\n", accept_pegin_txid));
+    s.push_str("\n");
+
+    let user_key_hex = user_pubkey.to_bytes().as_slice().to_lower_hex_string();
+    s.push_str("    bytes constant USER_COMPRESSED_PUBKEY =\n");
+    s.push_str(&format!("        hex\"{}\";\n", user_key_hex));
     s.push_str("\n");
 
     s.push_str(

--- a/examples/union/participants/common.rs
+++ b/examples/union/participants/common.rs
@@ -144,6 +144,108 @@ pub fn format_transaction_solidity(tx: &Transaction) -> String {
     output
 }
 
+fn tx_name_to_fn_name(tx_name: &str) -> String {
+    let base = if let Some(pos) = tx_name.find("_TX") {
+        &tx_name[..pos]
+    } else {
+        tx_name
+    };
+
+    let pascal: String = base
+        .split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase()
+                }
+            }
+        })
+        .collect();
+
+    format!("_getBitVMX{}Tx", pascal)
+}
+
+pub fn format_solidity_data_file(
+    committee_agg_key: &PublicKey,
+    dispute_keys: &[PublicKey],
+    request_pegin_tx: &Transaction,
+    accept_pegin_txid: Txid,
+    named_transactions: &[(&str, Transaction)],
+) -> String {
+    let mut s = String::new();
+
+    s.push_str("// SPDX-License-Identifier: Unlicense\n");
+    s.push_str("pragma solidity ^0.8.20;\n");
+    s.push_str("\n");
+    s.push_str("// GENERATED FILE - do not edit manually.\n");
+    s.push_str("// Run: ./examples/union/scripts/run-example.sh solidity_txs\n");
+    s.push_str("// from the rust-bitvmx-client directory.\n");
+    s.push_str("\n");
+    s.push_str(
+        "import {BtcTransaction, BtcTxIn, BtcTxOut} from \"src/interfaces/IBitcoinManager.sol\";\n",
+    );
+    s.push_str("import {CompactPubKey} from \"src/interfaces/IMemberRegistry.sol\";\n");
+    s.push_str("\n");
+    s.push_str("contract BitVMXCompatibilityData {\n");
+    s.push_str("    // All transactions below correspond to slot index 0 and operator index 1.\n");
+    s.push_str("    // These are fixed for testing purposes.\n");
+    s.push_str("\n");
+
+    let key_hex = committee_agg_key
+        .to_bytes()
+        .as_slice()
+        .to_lower_hex_string();
+    s.push_str("    bytes constant COMMITTEE_AGGREGATED_KEY =\n");
+    s.push_str(&format!("        hex\"{}\";\n", key_hex));
+    s.push_str("\n");
+
+    s.push_str("    bytes32 constant EXPECTED_ACCEPT_PEGIN_TXID =\n");
+    s.push_str(&format!("        0x{};\n", accept_pegin_txid));
+    s.push_str("\n");
+
+    s.push_str(
+        "    function _getBitVMXDisputeKeys() internal pure returns (CompactPubKey[] memory keys) {\n",
+    );
+    s.push_str(&format!(
+        "        keys = new CompactPubKey[]({});\n",
+        dispute_keys.len()
+    ));
+    for (i, key) in dispute_keys.iter().enumerate() {
+        let bytes = key.to_bytes();
+        let parity = bytes[0];
+        let x_only = &bytes[1..];
+        s.push_str(&format!(
+            "        keys[{}] = CompactPubKey({{parity: 0x{:02x}, xOnly: 0x{}}});\n",
+            i,
+            parity,
+            x_only.to_lower_hex_string()
+        ));
+    }
+    s.push_str("    }\n");
+    s.push_str("\n");
+
+    s.push_str("    function _getBitVMXRequestPeginTransaction() internal pure returns (BtcTransaction memory) {\n");
+    s.push_str(&format_transaction_solidity(request_pegin_tx));
+    s.push_str("\n    }\n");
+    s.push_str("\n");
+
+    for (name, tx) in named_transactions {
+        let fn_name = tx_name_to_fn_name(name);
+        s.push_str(&format!(
+            "    function {}() internal pure returns (BtcTransaction memory) {{\n",
+            fn_name
+        ));
+        s.push_str(&format_transaction_solidity(tx));
+        s.push_str("\n    }\n");
+        s.push_str("\n");
+    }
+
+    s.push_str("}\n");
+    s
+}
+
 pub fn prefixed_name(prefix: &str, name: &str) -> String {
     if prefix.is_empty() {
         return name.to_string();

--- a/examples/union/participants/member.rs
+++ b/examples/union/participants/member.rs
@@ -19,7 +19,7 @@ use bitvmx_client::{
         participant::{CommsAddress, ParticipantRole},
         protocols::union::{
             common::{
-                get_dispute_core_pid, get_dispute_pair_aggregated_key_pid,
+                get_advance_funds_pid, get_dispute_core_pid, get_dispute_pair_aggregated_key_pid,
                 get_dispute_pair_key_name, indexed_name,
             },
             dispute_core::PEGOUT_ID,
@@ -385,7 +385,6 @@ impl Member {
 
     pub fn advance_funds(
         &mut self,
-        protocol_id: Uuid,
         committee_id: Uuid,
         slot_index: usize,
         user_pubkey: PublicKey,
@@ -398,6 +397,8 @@ impl Member {
             "Advancing funds to user public key {}",
             user_pubkey.to_string()
         );
+
+        let protocol_id = get_advance_funds_pid(committee_id, slot_index);
 
         AdvanceFunds::setup(
             &self.bitvmx,

--- a/examples/union/participants/member.rs
+++ b/examples/union/participants/member.rs
@@ -185,14 +185,6 @@ impl Member {
     //         communication_pubkey.to_string()
     //     );
 
-    //     if is_deterministic {
-    //         if crate::participants::common::DEBUG_TX {
-    //             info!("Deterministic key UUIDs used (for reproducibility):");
-    //             info!("  - Take key UUID: {}", take_key_id);
-    //             info!("  - Dispute key UUID: {}", dispute_key_id);
-    //             info!("  - Communication key UUID: {}", comm_key_id);
-    //         }
-    //     }
 
     //     Ok((take_pubkey, dispute_pubkey, communication_pubkey))
     // }

--- a/examples/union/participants/user.rs
+++ b/examples/union/participants/user.rs
@@ -103,7 +103,7 @@ impl User {
         stream_value: u64,
         dispute_keys: &[PublicKey],
         request_pegin_timelock: u16,
-    ) -> Result<Txid> {
+    ) -> Result<(Txid, Transaction)> {
         info!(id = self.id, "Requesting pegin");
 
         // Enable RSK pegin monitoring using the public API
@@ -136,7 +136,7 @@ impl User {
         info!("Sent request pegin Tx: {}", txid);
         print_link(self.network, txid);
 
-        Ok(txid)
+        Ok((txid, signed_transaction))
     }
 
     pub fn get_request_pegin_spv(&self, request_pegin_txid: Txid) -> Result<BtcTxSPVProof> {

--- a/examples/union/participants/user.rs
+++ b/examples/union/participants/user.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::Result;
 use bitcoin::{
     absolute,
-    hex::{DisplayHex, FromHex},
+    hex::FromHex,
     key::Secp256k1,
     secp256k1::{self, All, Message, SecretKey},
     sighash::SighashCache,
@@ -308,14 +308,6 @@ impl User {
             signed_transaction.vsize()
         );
 
-        self.db_print_request_pegin_tx(
-            &signed_transaction,
-            stream_value,
-            packet_number,
-            request_pegin_timelock,
-            reimbursement_xpk,
-        );
-
         self.pop_request_pegin_utxo();
         Ok(signed_transaction)
     }
@@ -458,58 +450,6 @@ impl User {
         let mut address_bytes = [0u8; 20];
         address_bytes.copy_from_slice(Vec::from_hex(address).unwrap().as_slice());
         Ok(address_bytes)
-    }
-
-    /// Print reimbursement keys (x-only and compressed+parity) when debug is enabled
-    fn db_print_reimbursement_keys(&self, reimbursement_xpk: XOnlyPublicKey) {
-        if !crate::participants::common::DEBUG_TX {
-            return;
-        }
-
-        info!(
-            "  - Reimbursement Key (x-only): 0x{}",
-            reimbursement_xpk
-                .serialize()
-                .as_slice()
-                .to_lower_hex_string()
-        );
-
-        let reimbursement_compressed = self.public_key.to_bytes();
-        let parity = reimbursement_compressed[0];
-        info!(
-            "  - Reimbursement Key (compressed): 0x{} (parity: 0x{:02x})",
-            reimbursement_compressed.as_slice().to_lower_hex_string(),
-            parity
-        );
-    }
-
-    fn db_print_request_pegin_tx(
-        &self,
-        signed_transaction: &Transaction,
-        stream_value: u64,
-        packet_number: u64,
-        request_pegin_timelock: u16,
-        reimbursement_xpk: XOnlyPublicKey,
-    ) {
-        use crate::participants::common::db_print_transaction;
-
-        db_print_transaction(
-            "REQUEST PEGIN TRANSACTION DETAILS",
-            signed_transaction,
-            || {
-                info!("");
-                info!("Parameters Used:");
-                info!("  - Denomination: {} satoshis", stream_value);
-                info!("  - Packet Number: {}", packet_number);
-                info!("  - RSK Address: 0x{}", self.rsk_address);
-                self.db_print_reimbursement_keys(reimbursement_xpk);
-                info!(
-                    "  - Request Pegin Timelock: {} blocks",
-                    request_pegin_timelock
-                );
-                info!("");
-            },
-        );
     }
 
     fn sign_p2wpkh_transaction(

--- a/examples/union/scripts/run-example.sh
+++ b/examples/union/scripts/run-example.sh
@@ -81,4 +81,4 @@ else
 fi
 
 printf "\nRunning union example: $name...\n\n\n"
-RUST_BACKTRACE=full cargo run --release --example union $cmd 2>&1 | sed -u -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGKHF]//g" > "$EXAMPLE_LOG_FILE"
+RUST_BACKTRACE=full EXAMPLE_LOG_DIR="$LOGS_DIR" cargo run --release --example union $cmd 2>&1 | sed -u -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[mGKHF]//g" > "$EXAMPLE_LOG_FILE"

--- a/src/program/protocols/union/advance_funds.rs
+++ b/src/program/protocols/union/advance_funds.rs
@@ -158,7 +158,7 @@ impl ProtocolHandler for AdvanceFundsProtocol {
         )?;
 
         // Add op return output
-        let script_op_return = op_return_script(request.pegout_id)?;
+        let script_op_return = op_return_script(request.pegout_id.clone())?;
         protocol.add_transaction_output(
             ADVANCE_FUNDS_TX,
             &OutputType::segwit_unspendable(script_op_return.get_script().clone())?,
@@ -192,6 +192,16 @@ impl ProtocolHandler for AdvanceFundsProtocol {
                 },
             )?;
         }
+
+        let dispute_protocol_id =
+            get_dispute_core_pid(request.committee_id, &request.my_take_pubkey);
+
+        self.save_pegout_id(
+            context,
+            dispute_protocol_id,
+            request.pegout_id,
+            request.slot_index,
+        )?;
 
         protocol.build(&context.key_manager, &self.ctx.protocol_name)?;
         info!("\n{}", protocol.visualize(GraphOptions::EdgeArrows)?);
@@ -243,13 +253,6 @@ impl ProtocolHandler for AdvanceFundsProtocol {
 
             let dispute_protocol_id =
                 get_dispute_core_pid(request.committee_id, &request.my_take_pubkey);
-
-            self.save_pegout_id(
-                context,
-                dispute_protocol_id,
-                request.pegout_id,
-                request.slot_index,
-            )?;
 
             self.dispatch_reimbursement_tx(
                 context,

--- a/src/program/protocols/union/common.rs
+++ b/src/program/protocols/union/common.rs
@@ -46,6 +46,17 @@ pub fn get_accept_pegin_pid(committee_id: Uuid, slot_index: usize) -> Uuid {
     return Uuid::from_bytes(hash[0..16].try_into().unwrap());
 }
 
+pub fn get_advance_funds_pid(committee_id: Uuid, slot_index: usize) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(committee_id.as_bytes());
+    hasher.update(&slot_index.to_be_bytes());
+    hasher.update("advance_funds");
+
+    // Get the result as a byte array
+    let hash = hasher.finalize();
+    return Uuid::from_bytes(hash[0..16].try_into().unwrap());
+}
+
 pub fn get_user_take_pid(committee_id: Uuid, slot_index: usize) -> Uuid {
     let mut hasher = Sha256::new();
     hasher.update(committee_id.as_bytes());

--- a/src/program/protocols/union/dispute_core.rs
+++ b/src/program/protocols/union/dispute_core.rs
@@ -544,6 +544,8 @@ impl ProtocolHandler for DisputeCoreProtocol {
             Ok(self.reimbursement_kickoff_tx(name, context)?)
         } else if name.starts_with(CHALLENGE_TX) {
             Ok(self.challenge_tx(name, context)?)
+        } else if name.starts_with(REVEAL_INPUT_TX) {
+            Ok(self.reveal_input_tx(name, context)?)
         } else if name == WT_SELF_DISABLER_TX || name == OP_SELF_DISABLER_TX {
             Ok(self.sign_aggregated_input(name, context, false)?)
         } else if name.starts_with(WT_INIT_CHALLENGE_TX) {
@@ -2506,11 +2508,11 @@ impl DisputeCoreProtocol {
         &self,
         name: &str,
         context: &ProgramContext,
-        slot_index: usize,
     ) -> Result<(Transaction, Option<SpeedupData>), BitVMXError> {
         info!(id = self.ctx.my_idx, "Loading {} for DisputeCore", name);
 
         let mut protocol = self.load_protocol()?;
+        let slot_index = extract_index(name, REVEAL_INPUT_TX)? as u16;
 
         let args = collect_input_signatures(
             &mut protocol,
@@ -2519,7 +2521,7 @@ impl DisputeCoreProtocol {
                 input_index: REVEAL_INPUT_TX_REVEAL_INDEX,
                 script_index: REVEAL_INPUT_TX_REVEAL_LEAF,
                 winternitz_data: Some(WinternitzData {
-                    data: (slot_index as u16).to_be_bytes().to_vec(),
+                    data: slot_index.to_be_bytes().to_vec(),
                     key_name: SLOT_ID_KEY.to_string(),
                     key_type: WinternitzType::HASH160,
                     key_manager: context.key_manager.as_ref(),
@@ -2857,9 +2859,7 @@ impl DisputeCoreProtocol {
             DisputeCoreTxType::WatchtowerNoChallenge { .. } => self.wt_no_challenge_tx(&tx_name)?,
             DisputeCoreTxType::OperatorNoCosign { .. } => self.op_no_cosign_tx(&tx_name)?,
             DisputeCoreTxType::OperatorCosign { .. } => self.op_cosign_tx(&tx_name, context)?,
-            DisputeCoreTxType::RevealInput { slot_index } => {
-                self.reveal_input_tx(&tx_name, context, slot_index)?
-            }
+            DisputeCoreTxType::RevealInput { .. } => self.reveal_input_tx(&tx_name, context)?,
             DisputeCoreTxType::InputNotRevealed { .. } => {
                 self.input_not_revealed_tx(&tx_name, context)?
             }
@@ -3215,10 +3215,16 @@ impl DisputeCoreProtocol {
         context: &ProgramContext,
         slot_index: usize,
     ) -> Result<Vec<u8>, BitVMXError> {
+        let key = indexed_name(PEGOUT_ID, slot_index);
         context
             .globals
-            .get_var(&self.ctx.id, &indexed_name(PEGOUT_ID, slot_index))?
-            .unwrap()
+            .get_var(&self.ctx.id, &key)?
+            .ok_or_else(|| {
+                BitVMXError::InvalidParameter(format!(
+                    "Key {} not set in uuid: {}",
+                    key, self.ctx.id
+                ))
+            })?
             .input()
     }
 

--- a/src/program/protocols/union/dispute_core.rs
+++ b/src/program/protocols/union/dispute_core.rs
@@ -42,7 +42,7 @@ use protocol_builder::{
     builder::Protocol,
     graph::graph::GraphOptions,
     scripts::{
-        op_return, op_return_script, timelock, verify_signature,
+        op_return_script, timelock, verify_signature,
         verify_winternitz_signature_timelock, SignMode,
     },
     types::{
@@ -1258,12 +1258,6 @@ impl DisputeCoreProtocol {
             InputSpec::Auto(SighashType::taproot_all(), SpendMode::ScriptsOnly),
             Some(settings.input_not_revealed_timelock),
             None,
-        )?;
-
-        // TODO: Should we remove this output? If so, need to update input_not_revealed_tx with correct speedup output index
-        protocol.add_transaction_output(
-            &input_not_revealed,
-            &OutputType::segwit_unspendable(op_return(vec![]))?,
         )?;
 
         self.add_dispute_core_speedup_outputs(
@@ -2570,7 +2564,7 @@ impl DisputeCoreProtocol {
         // Speedup data
         let speedup_utxo = Utxo::new(
             tx.compute_txid(),
-            1 + self.ctx.my_idx as u32, //Speedup vout is member index + 1 (1 is because op return output)
+            self.ctx.my_idx as u32, //Speedup vout is member index
             SPEEDUP_VALUE,
             &self.my_speedup_key(context)?,
         );

--- a/src/program/protocols/union/dispute_core.rs
+++ b/src/program/protocols/union/dispute_core.rs
@@ -546,6 +546,8 @@ impl ProtocolHandler for DisputeCoreProtocol {
             Ok(self.challenge_tx(name, context)?)
         } else if name.starts_with(REVEAL_INPUT_TX) {
             Ok(self.reveal_input_tx(name, context)?)
+        } else if name.starts_with(INPUT_NOT_REVEALED_TX) {
+            Ok(self.input_not_revealed_tx(name, context)?)
         } else if name == WT_SELF_DISABLER_TX || name == OP_SELF_DISABLER_TX {
             Ok(self.sign_aggregated_input(name, context, false)?)
         } else if name.starts_with(WT_INIT_CHALLENGE_TX) {


### PR DESCRIPTION
This PR adds the necessary code to the example that now generates the BitVMXCompatibilityData.sol file to be able to test that the transactions generated by this repo match the expected format in the contracts repo.

https://github.com/temp-rsk/bitvmx-union-bridge-contracts/pull/446