### PR TITLE
feat: add generic async setup step for external dispatchers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -77,4 +77,6 @@ pub trait BitVMXApi {
     fn get_spv_proof(&mut self, from: Identifier, txid: Txid) -> Result<(), BitVMXError>;
 
     fn handle_emulator_message(&mut self, msg: &String) -> Result<(), BitVMXError>;
+
+    fn handle_garbled_message(&mut self, msg: String) -> Result<(), BitVMXError>;
 }

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -248,6 +248,25 @@ impl BitVMX {
         &self.config.components
     }
 
+    /// Sets the garbled dispatcher identifier for both config and program context.
+    pub fn set_garbled_identifier(&mut self, identifier: Identifier) {
+        self.config.components.garbled = Some(identifier.clone());
+        self.program_context.components_config.garbled = Some(identifier);
+    }
+
+    /// Register an async step handler for a given step name.
+    ///
+    /// The handler will be used by `AsyncDispatcherStep` when the matching
+    /// step runs during protocol setup.
+    pub fn register_async_step_handler(
+        &mut self,
+        step_name: &str,
+        handler: crate::program::setup::steps::AsyncStepHandlerEnum,
+    ) {
+        self.program_context
+            .register_async_step_handler(step_name, handler);
+    }
+
     pub fn get_store(&self) -> Rc<Storage> {
         self.store.clone()
     }
@@ -1248,6 +1267,30 @@ impl BitVMXApi for BitVMX {
         Ok(())
     }
 
+    fn handle_garbled_message(&mut self, msg: String) -> Result<(), BitVMXError> {
+        if let Some(message) = serde_json::from_str::<PingMessage>(&msg).ok() {
+            self.ping_helper
+                .received_message(JobDispatcherType::Garbled, &message);
+        } else {
+            let result_message = ResultMessage::from_str(&msg)?;
+            let result_data = result_message.result.as_bytes();
+
+            // The job_id is the program_id (set during generate_data in AsyncDispatcherStep)
+            let program_id = Uuid::parse_str(&result_message.job_id)
+                .map_err(|_| BitVMXError::InvalidMessageFormat)?;
+
+            info!(
+                "handle_garbled_message: Received result for program {}",
+                program_id
+            );
+
+            // Route the result to the program's setup engine
+            let mut program = self.load_program(&program_id)?;
+            program.receive_async_generation_result(result_data, &mut self.program_context)?;
+        }
+        Ok(())
+    }
+
     fn handle_emulator_message(&mut self, msg: &String) -> Result<(), BitVMXError> {
         if let Some(message) = serde_json::from_str::<PingMessage>(&msg).ok() {
             self.ping_helper
@@ -1304,6 +1347,13 @@ impl BitVMXApi for BitVMX {
         if from == self.config.components.prover {
             self.handle_prover_message(msg)?;
             return Ok(());
+        }
+
+        if let Some(garbled_id) = &self.config.components.garbled {
+            if from == *garbled_id {
+                self.handle_garbled_message(msg)?;
+                return Ok(());
+            }
         }
 
         let decoded: IncomingBitVMXApiMessages = serde_json::from_str(&msg)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,8 @@ pub struct ComponentsConfig {
     pub bitvmx: Identifier,
     pub emulator: Identifier,
     pub prover: Identifier,
+    /// Garbled circuits dispatcher (optional, needed for protocols that use garbled circuits)
+    pub garbled: Option<Identifier>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/src/ping_helper.rs
+++ b/src/ping_helper.rs
@@ -14,6 +14,7 @@ use tracing::{debug, warn};
 pub(crate) enum JobDispatcherType {
     ZKP,
     Emulator,
+    Garbled,
 }
 
 pub(crate) struct PingHelper {
@@ -108,6 +109,20 @@ impl PingHelper {
 
         self.time_since_sent_check
             .insert(JobDispatcherType::Emulator, Instant::now());
+
+        // Ping garbled dispatcher if configured
+        if let Some(garbled_id) = &components.garbled {
+            let msg_to_garbled = serde_json::to_string(&PingMessage::Ping)?;
+            debug!(
+                "Sending Garbled dispatcher ping message: {}",
+                msg_to_garbled
+            );
+            program_context
+                .broker_channel
+                .send(garbled_id, msg_to_garbled)?;
+            self.time_since_sent_check
+                .insert(JobDispatcherType::Garbled, Instant::now());
+        }
 
         Ok(())
     }

--- a/src/program/program.rs
+++ b/src/program/program.rs
@@ -410,6 +410,43 @@ impl Program {
         Ok(message_processed)
     }
 
+    /// Receives the result of an async generation operation for the current setup step.
+    ///
+    /// This is called when a job dispatcher returns the result for an async setup step
+    pub fn receive_async_generation_result(
+        &mut self,
+        result: &[u8],
+        program_context: &mut ProgramContext,
+    ) -> Result<(), BitVMXError> {
+        if !matches!(self.state, ProgramState::SettingUp) {
+            debug!("Program::receive_async_generation_result() - Not in SettingUp state, ignoring");
+            return Ok(());
+        }
+
+        let state_changed = if let Some(engine) = &mut self.setup_engine {
+            engine.receive_async_result(
+                result,
+                &mut self.protocol,
+                &self.participants,
+                self.my_idx,
+                &self.program_id,
+                self.leader,
+                program_context,
+            )?
+        } else {
+            false
+        };
+
+        if state_changed {
+            self.save()?;
+            info!(
+                "Program::receive_async_generation_result() - Saved program state after async result"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Returns the protocol ID
     pub fn protocol_id(&self) -> Uuid {
         self.protocol.context().id

--- a/src/program/protocols/garbled.rs
+++ b/src/program/protocols/garbled.rs
@@ -1,0 +1,91 @@
+/// GarbledProtocol - Simple protocol for testing async garbled circuit setup step.
+///
+/// Uses [Keys, GarbledCircuits] setup steps to exercise the async generation flow.
+/// The Keys step exchanges keys normally. The GarbledCircuits step sends a job
+/// to the garbled-dispatcher and waits for the result asynchronously.
+///
+/// This protocol does NOT build Bitcoin transactions. It only tests the setup flow
+/// with an async step, similar to AggregatedKeyProtocol but with a garbled step.
+use bitcoin::PublicKey;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::{
+    errors::BitVMXError,
+    program::{
+        participant::ParticipantKeys,
+        protocols::protocol_handler::{ProtocolContext, ProtocolHandler},
+        setup::steps::SetupStepName,
+        variables::VariableTypes,
+    },
+    types::ProgramContext,
+};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct GarbledProtocol {
+    ctx: ProtocolContext,
+}
+
+impl GarbledProtocol {
+    pub fn new(ctx: ProtocolContext) -> Self {
+        Self { ctx }
+    }
+}
+
+impl ProtocolHandler for GarbledProtocol {
+    fn context(&self) -> &ProtocolContext {
+        &self.ctx
+    }
+
+    fn context_mut(&mut self) -> &mut ProtocolContext {
+        &mut self.ctx
+    }
+
+    fn generate_keys(
+        &self,
+        program_context: &mut ProgramContext,
+    ) -> Result<ParticipantKeys, BitVMXError> {
+        let key = program_context
+            .key_manager
+            .next_keypair(key_manager::key_type::BitcoinKeyType::P2tr)?;
+
+        let key_name = format!("garbled_{}", self.ctx.id);
+        Ok(ParticipantKeys::new(
+            vec![(key_name.clone(), key.into())],
+            vec![key_name],
+        ))
+    }
+
+    fn build(
+        &self,
+        _keys: Vec<ParticipantKeys>,
+        computed_aggregated: HashMap<String, PublicKey>,
+        context: &ProgramContext,
+    ) -> Result<(), BitVMXError> {
+        let key_name = format!("garbled_{}", self.ctx.id);
+
+        let aggregated_key = computed_aggregated.get(&key_name).ok_or_else(|| {
+            BitVMXError::InvalidMessage(format!(
+                "Pre-computed aggregated key '{}' not found",
+                key_name
+            ))
+        })?;
+
+        context.globals.set_var(
+            &self.ctx.id,
+            "garbled_aggregated_key",
+            VariableTypes::PubKey(*aggregated_key),
+        )?;
+
+        tracing::info!(
+            "GarbledProtocol::build() - Stored aggregated key for program {}",
+            self.ctx.id
+        );
+
+        Ok(())
+    }
+
+    fn setup_steps(&self) -> Option<Vec<SetupStepName>> {
+        Some(vec![SetupStepName::Keys, SetupStepName::GarbledCircuits])
+    }
+}

--- a/src/program/protocols/mod.rs
+++ b/src/program/protocols/mod.rs
@@ -3,6 +3,7 @@ pub mod aggregated_key;
 pub mod cardinal;
 pub mod claim;
 pub mod dispute;
+pub mod garbled;
 pub mod protocol_handler;
 pub mod protocol_type;
 #[cfg(feature = "union")]

--- a/src/program/protocols/protocol_handler.rs
+++ b/src/program/protocols/protocol_handler.rs
@@ -24,6 +24,7 @@ use crate::errors::BitVMXError;
 use crate::program::protocols::union::full_penalization::FullPenalizationProtocol;
 
 use super::aggregated_key::AggregatedKeyProtocol;
+use super::garbled::GarbledProtocol;
 #[cfg(feature = "cardinal")]
 use super::cardinal::{lock::LockProtocol, slot::SlotProtocol, transfer::TransferProtocol};
 use super::dispute::DisputeResolutionProtocol;
@@ -45,7 +46,9 @@ use crate::types::{
 #[cfg(feature = "cardinal")]
 use crate::types::{PROGRAM_TYPE_LOCK, PROGRAM_TYPE_SLOT, PROGRAM_TYPE_TRANSFER};
 
-use crate::types::{ProgramContext, PROGRAM_TYPE_AGGREGATED_KEY, PROGRAM_TYPE_DRP};
+use crate::types::{
+    ProgramContext, PROGRAM_TYPE_AGGREGATED_KEY, PROGRAM_TYPE_DRP, PROGRAM_TYPE_GARBLED,
+};
 
 use crate::program::setup::steps::SetupStepName;
 use crate::program::variables::WitnessTypes;
@@ -642,6 +645,7 @@ impl ProtocolContext {
 #[derive(Clone, Serialize, Deserialize)]
 pub enum ProtocolType {
     AggregatedKeyProtocol,
+    GarbledProtocol,
     DisputeResolutionProtocol,
     #[cfg(feature = "cardinal")]
     LockProtocol,
@@ -677,6 +681,9 @@ pub fn new_protocol_type(
     match name {
         PROGRAM_TYPE_AGGREGATED_KEY => Ok(ProtocolType::AggregatedKeyProtocol(
             AggregatedKeyProtocol::new(ctx),
+        )),
+        PROGRAM_TYPE_GARBLED => Ok(ProtocolType::GarbledProtocol(
+            GarbledProtocol::new(ctx),
         )),
         PROGRAM_TYPE_DRP => Ok(ProtocolType::DisputeResolutionProtocol(
             DisputeResolutionProtocol::new(ctx),

--- a/src/program/setup/setup_engine.rs
+++ b/src/program/setup/setup_engine.rs
@@ -18,11 +18,26 @@ use super::{
     SetupStep,
 };
 
+/// Wrapper that tags setup step data with the step name.
+///
+/// This allows the receiver to identify which step the data belongs to and
+/// ignore stale messages from already-completed steps.
+#[derive(Serialize, Deserialize)]
+struct SetupStepMessage {
+    step_name: String,
+    data: Vec<u8>,
+}
+
 /// Current state of a setup step in the engine.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum StepState {
     /// Step is generating data
     Generating,
+    /// Step has initiated an async operation and is waiting for the result.
+    /// Only used by async steps (where `SetupStep::is_async() == true`).
+    /// Transitions to `WaitingForParticipants` when the async result arrives
+    /// via `SetupEngine::receive_async_result()`.
+    WaitingGeneration,
     /// Step has sent data and is waiting for other participants
     WaitingForParticipants,
     /// All participants have sent data and step is ready to advance to the next step
@@ -223,10 +238,13 @@ impl SetupEngine {
         // Now get the step and generate data
         let step = &self.steps[self.state.current_step_index];
         let data = step.generate_data(protocol, context)?;
-        //TODO: for steps that generate data asyn, instead of moving to waiting, move to a new state "WaitingGeneration"
-        //that will be handled with another external call and would allow the transition
 
-        if total_participants == 1
+        if data.is_none() && step.is_async() {
+            // Async step: generate_data() initiated an async operation (e.g., sent a job
+            // to a dispatcher) but doesn't have the result yet. Transition to WaitingGeneration
+            // and wait for receive_async_result() to be called with the result.
+            self.state.current_step_state = StepState::WaitingGeneration;
+        } else if total_participants == 1
             || self.state.participants_completed.len() == total_participants - 1
         {
             self.state.current_step_state = StepState::AllParticipantsCompleted;
@@ -387,6 +405,7 @@ impl SetupEngine {
     /// - When all data is received, leader broadcasts to all non-leaders
     fn broadcast_setup_data(
         &self,
+        step_name: &str,
         data: Vec<u8>,
         program_id: &Uuid,
         my_idx: usize,
@@ -396,11 +415,19 @@ impl SetupEngine {
     ) -> Result<(), BitVMXError> {
         let is_leader = my_idx == leader;
 
+        // Wrap data with step name so the receiver can route it correctly
+        let wrapped = SetupStepMessage {
+            step_name: step_name.to_string(),
+            data,
+        };
+        let wrapped_data = serde_json::to_vec(&wrapped)?;
+
         if is_leader {
             // Leader: Store own message for later broadcast
             info!(
-                "SetupEngine::broadcast_setup_data() - Leader storing own {} bytes",
-                data.len()
+                "SetupEngine::broadcast_setup_data() - Leader storing own {} bytes for step '{}'",
+                wrapped_data.len(),
+                step_name
             );
 
             // Prepare the message (serialize + sign)
@@ -409,7 +436,7 @@ impl SetupEngine {
                 &context.rsa_public_key,
                 program_id,
                 CommsMessageType::SetupStepData,
-                data,
+                wrapped_data,
             )?;
 
             // Create OriginalMessage
@@ -433,9 +460,10 @@ impl SetupEngine {
             let leader_address = &participants[leader];
 
             info!(
-                "SetupEngine::broadcast_setup_data() - Non-leader sending {} bytes to leader {}",
-                data.len(),
-                leader_address.pubkey_hash
+                "SetupEngine::broadcast_setup_data() - Non-leader sending {} bytes to leader {} for step '{}'",
+                wrapped_data.len(),
+                leader_address.pubkey_hash,
+                step_name
             );
 
             request(
@@ -445,7 +473,7 @@ impl SetupEngine {
                 program_id,
                 leader_address.clone(),
                 CommsMessageType::SetupStepData,
-                data,
+                wrapped_data,
             )?;
         }
 
@@ -487,22 +515,34 @@ impl SetupEngine {
             return Ok(false);
         }
 
+        // Unwrap the step message
+        let step_msg: SetupStepMessage = serde_json::from_slice(data)?;
+
+        // Check if the message is for the current step
+        let current_step_name = self.current_step_name().to_string();
+        if step_msg.step_name != current_step_name {
+            warn!(
+                "SetupEngine::receive_setup_data() - Ignoring data for step '{}' (current step is '{}')",
+                step_msg.step_name, current_step_name
+            );
+            return Ok(false);
+        }
+
         // Find the participant
         let from_participant = get_comms_address_by_pubkey_hash(participants, from)?;
 
-        let step_name = self.current_step_name().to_string();
         let participants_completed_before = self.state.participants_completed.len();
 
         info!(
             "SetupEngine::receive_setup_data() - Processing data for step '{}' (completed before: {}/{})",
-            step_name,
+            current_step_name,
             participants_completed_before,
             participants.len()
         );
 
-        // Receive and verify the data
+        // Receive and verify the inner data
         if !self.receive_current_step_data(
-            data,
+            &step_msg.data,
             my_idx,
             &from_participant,
             protocol,
@@ -511,7 +551,7 @@ impl SetupEngine {
         )? {
             debug!(
                 "SetupEngine::receive_setup_data() - Data from participant {} did not change state for step '{}'",
-                from, step_name
+                from, current_step_name
             );
             return Ok(false);
         }
@@ -561,6 +601,95 @@ impl SetupEngine {
         }
 
         // Receiving data always changes the engine state
+        Ok(true)
+    }
+
+    /// Receives the result of an async generation operation.
+    ///
+    /// Called when an async step (one where `is_async() == true`) receives its result
+    /// from an external source (e.g., a job dispatcher). This method:
+    /// 1. Validates the engine is in `WaitingGeneration` state
+    /// 2. Delegates to the step's `receive_generation_result()` to process the result
+    /// 3. Stores own data in globals
+    /// 4. Broadcasts the data to other participants
+    /// 5. Transitions to `WaitingForParticipants`
+    ///
+    /// Returns whether the engine state changed.
+    pub fn receive_async_result(
+        &mut self,
+        result: &[u8],
+        protocol: &mut ProtocolType,
+        participants: &[CommsAddress],
+        my_idx: usize,
+        program_id: &Uuid,
+        leader: usize,
+        context: &mut ProgramContext,
+    ) -> Result<bool, BitVMXError> {
+        self.if_not_completed()?;
+
+        let step_name = self.current_step_name().to_string();
+
+        if self.state.current_step_state != StepState::WaitingGeneration {
+            return Err(BitVMXError::InvalidState(format!(
+                "Cannot receive async result: step '{}' is not in WaitingGeneration state (current: {:?})",
+                step_name, self.state.current_step_state
+            )));
+        }
+
+        info!(
+            "SetupEngine::receive_async_result() - Processing async result ({} bytes) for step '{}'",
+            result.len(),
+            step_name
+        );
+
+        // Delegate to the step to process the result
+        let step = &self.steps[self.state.current_step_index];
+        let data = step.receive_generation_result(result, protocol, context)?;
+
+        // Transition to WaitingForParticipants
+        self.state.current_step_state = StepState::WaitingForParticipants;
+
+        if let Some(ref d) = data {
+            info!(
+                "SetupEngine::receive_async_result() - Step '{}' produced {} bytes to broadcast",
+                step_name,
+                d.len()
+            );
+
+            // Store our own data in globals
+            let my_participant = &participants[my_idx];
+            self.current_step().verify_received(
+                d,
+                my_participant,
+                protocol,
+                participants,
+                context,
+            )?;
+
+            // Broadcast the data to other participants
+            self.broadcast_setup_data(
+                &step_name,
+                d.clone(),
+                program_id,
+                my_idx,
+                leader,
+                participants,
+                context,
+            )?;
+
+            self.state.mark_participant_completed(my_idx);
+
+            info!(
+                "SetupEngine::receive_async_result() - Broadcasted data and marked self as completed for step '{}'",
+                step_name
+            );
+        } else {
+            info!(
+                "SetupEngine::receive_async_result() - Step '{}' produced no data to broadcast",
+                step_name
+            );
+        }
+
         Ok(true)
     }
 
@@ -638,6 +767,13 @@ impl SetupEngine {
                         );
 
                     data_to_send = Some(d.clone());
+                } else if self.state.current_step_state == StepState::WaitingGeneration {
+                    // Async step: generate_data() initiated an async operation.
+                    // We'll wait for receive_async_result() to deliver the result.
+                    info!(
+                        "SetupEngine::tick() - Async step '{}' is now WaitingGeneration",
+                        step_name
+                    );
                 } else {
                     info!(
                         "SetupEngine::tick() - Step '{}' generated no data",
@@ -645,6 +781,13 @@ impl SetupEngine {
                     );
                 }
                 state_changed = true;
+            }
+            StepState::WaitingGeneration => {
+                // Async step: waiting for external result via receive_async_result()
+                debug!(
+                    "SetupEngine::tick() - Step '{}' is WaitingGeneration, waiting for async result",
+                    step_name
+                );
             }
             StepState::WaitingForParticipants => {
                 info!("Wasted");
@@ -692,6 +835,7 @@ impl SetupEngine {
 
             // Broadcast the data
             self.broadcast_setup_data(
+                &step_name,
                 data.clone(),
                 program_id,
                 my_idx,

--- a/src/program/setup/setup_step.rs
+++ b/src/program/setup/setup_step.rs
@@ -75,4 +75,35 @@ pub trait SetupStep {
     ) -> Result<(), BitVMXError> {
         Ok(())
     }
+
+    /// Returns true if this step generates data asynchronously.
+    ///
+    /// Async steps work differently from sync steps:
+    /// - `generate_data()` initiates the async operation (e.g., sends a job to a dispatcher)
+    ///   and returns `None`
+    /// - The engine transitions to `WaitingGeneration` instead of `WaitingForParticipants`
+    /// - When the async result arrives, `receive_generation_result()` is called
+    /// - The engine then transitions to `WaitingForParticipants` and broadcasts the data
+    ///
+    /// Default: false (synchronous step).
+    fn is_async(&self) -> bool {
+        false
+    }
+
+    /// Called when an async generation result arrives from an external source.
+    ///
+    /// Only relevant for async steps (`is_async() == true`).
+    /// Should process the result and return the data to broadcast to other participants.
+    ///
+    /// Default: returns error (not an async step).
+    fn receive_generation_result(
+        &self,
+        _result: &[u8],
+        _protocol: &mut ProtocolType,
+        _context: &mut ProgramContext,
+    ) -> Result<Option<Vec<u8>>, BitVMXError> {
+        Err(BitVMXError::InvalidMessage(
+            "receive_generation_result called on a non-async step".to_string(),
+        ))
+    }
 }

--- a/src/program/setup/steps/async_dispatcher_step.rs
+++ b/src/program/setup/steps/async_dispatcher_step.rs
@@ -1,0 +1,297 @@
+use crate::{
+    config::ComponentsConfig,
+    errors::BitVMXError,
+    program::{
+        participant::{get_index_by_pubkey_hash, CommsAddress},
+        protocols::protocol_handler::{ProtocolHandler, ProtocolType},
+        setup::SetupStep,
+        variables::VariableTypes,
+    },
+    types::ProgramContext,
+};
+use bitvmx_broker::identification::identifier::Identifier;
+use enum_dispatch::enum_dispatch;
+use tracing::{debug, info};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// AsyncStepHandler trait
+// ---------------------------------------------------------------------------
+
+/// Trait for handling async dispatcher interactions in setup steps.
+///
+/// Implementations define how to create jobs for a specific dispatcher,
+/// parse its results, and validate data received from peers.
+///
+/// ## Adding a new async dispatcher type
+///
+/// 1. Implement this trait for your handler
+/// 2. Add a variant to `AsyncStepHandlerEnum` and `SetupStepName`
+/// 3. Map the step name to `AsyncDispatcher(AsyncDispatcherStep::new("..."))` in `create_setup_step`
+/// 4. Register the handler on `ProgramContext` before running the protocol:
+#[enum_dispatch]
+pub trait AsyncStepHandler {
+    /// Create a serialized job message to send to the dispatcher.
+    ///
+    /// Returns the serialized JSON string ready to send via broker.
+    fn create_job(
+        &self,
+        protocol_id: &Uuid,
+        protocol: &mut ProtocolType,
+    ) -> Result<String, BitVMXError>;
+
+    /// Parse the raw dispatcher result and return a JSON string to broadcast to peers.
+    ///
+    /// The returned string is stored in globals and sent to other participants.
+    fn parse_result(&self, result: &[u8]) -> Result<String, BitVMXError>;
+
+    /// Validate data received from a peer before storing.
+    fn validate_received(&self, data: &str) -> Result<(), BitVMXError>;
+
+    /// Return the dispatcher Identifier from the components config.
+    fn dispatcher_id(&self, config: &ComponentsConfig) -> Option<Identifier>;
+}
+
+// ---------------------------------------------------------------------------
+// AsyncDispatcherStep
+// ---------------------------------------------------------------------------
+
+/// Generic async setup step that delegates to an [`AsyncStepHandler`].
+///
+/// This step sends a job to an external dispatcher, waits for the result,
+/// then exchanges it with all participants. The specific job format and
+/// result parsing are determined by the handler registered in `ProgramContext`.
+///
+/// ## Flow
+/// 1. `generate_data()` → handler creates job → sends to dispatcher → returns `None`
+/// 2. Engine waits in `WaitingGeneration` state
+/// 3. Dispatcher result arrives → `receive_generation_result()` → handler parses result
+/// 4. Engine transitions to `WaitingForParticipants` and broadcasts data
+/// 5. All participants exchange and verify data via handler
+#[derive(Debug, Clone)]
+pub struct AsyncDispatcherStep {
+    name: String,
+}
+
+impl AsyncDispatcherStep {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+        }
+    }
+}
+
+impl SetupStep for AsyncDispatcherStep {
+    fn step_name(&self) -> &str {
+        &self.name
+    }
+
+    fn is_async(&self) -> bool {
+        true
+    }
+
+    fn generate_data(
+        &self,
+        protocol: &mut ProtocolType,
+        context: &mut ProgramContext,
+    ) -> Result<Option<Vec<u8>>, BitVMXError> {
+        let protocol_id = protocol.context().id;
+
+        info!(
+            "AsyncDispatcherStep[{}]: Sending job for protocol {}",
+            self.name, protocol_id
+        );
+
+        // Extract what we need from the handler, then drop the borrow on context
+        let (msg, dispatcher_id) = {
+            let handler = context.async_step_handlers.get(&self.name).ok_or_else(|| {
+                BitVMXError::InvalidMessage(format!(
+                    "No AsyncStepHandler registered for step '{}'",
+                    self.name
+                ))
+            })?;
+
+            let msg = handler.create_job(&protocol_id, protocol)?;
+            let id = handler
+                .dispatcher_id(&context.components_config)
+                .ok_or_else(|| {
+                    BitVMXError::InvalidMessage(format!(
+                        "Dispatcher not configured for async step '{}'",
+                        self.name
+                    ))
+                })?;
+            (msg, id)
+        };
+
+        context.broker_channel.send(&dispatcher_id, msg)?;
+        info!("AsyncDispatcherStep[{}]: Job sent to dispatcher", self.name);
+
+        Ok(None)
+    }
+
+    fn receive_generation_result(
+        &self,
+        result: &[u8],
+        protocol: &mut ProtocolType,
+        context: &mut ProgramContext,
+    ) -> Result<Option<Vec<u8>>, BitVMXError> {
+        let protocol_id = protocol.context().id;
+
+        info!(
+            "AsyncDispatcherStep[{}]: Received async result ({} bytes) for protocol {}",
+            self.name,
+            result.len(),
+            protocol_id
+        );
+
+        let data_string = {
+            let handler = context.async_step_handlers.get(&self.name).ok_or_else(|| {
+                BitVMXError::InvalidMessage(format!(
+                    "No AsyncStepHandler registered for step '{}'",
+                    self.name
+                ))
+            })?;
+            handler.parse_result(result)?
+        };
+
+        debug!(
+            "AsyncDispatcherStep[{}]: Parsed result ({} chars)",
+            self.name,
+            data_string.len()
+        );
+
+        // Store in globals
+        context.globals.set_var(
+            &protocol_id,
+            &format!("my_{}", self.name),
+            VariableTypes::String(data_string.clone()),
+        )?;
+
+        // Convert to bytes for broadcast
+        Ok(Some(data_string.into_bytes()))
+    }
+
+    fn verify_received(
+        &self,
+        data: &[u8],
+        from_participant: &CommsAddress,
+        protocol: &ProtocolType,
+        participants: &[CommsAddress],
+        context: &mut ProgramContext,
+    ) -> Result<(), BitVMXError> {
+        let protocol_id = protocol.context().id;
+
+        debug!(
+            "AsyncDispatcherStep[{}]: Verifying data from participant {}",
+            self.name, from_participant.pubkey_hash
+        );
+
+        let data_str = std::str::from_utf8(data).map_err(|e| {
+            BitVMXError::InvalidMessage(format!("Invalid UTF-8 in async step data: {}", e))
+        })?;
+
+        // Validate via handler
+        {
+            let handler = context.async_step_handlers.get(&self.name).ok_or_else(|| {
+                BitVMXError::InvalidMessage(format!(
+                    "No AsyncStepHandler registered for step '{}'",
+                    self.name
+                ))
+            })?;
+            handler.validate_received(data_str)?;
+        }
+
+        // Find participant index and store
+        let idx = get_index_by_pubkey_hash(participants, &from_participant.pubkey_hash)?;
+
+        context.globals.set_var(
+            &protocol_id,
+            &format!("participant_{}_{}", idx, self.name),
+            VariableTypes::String(data_str.to_string()),
+        )?;
+
+        debug!(
+            "AsyncDispatcherStep[{}]: Stored data from participant {} at index {}",
+            self.name, from_participant.pubkey_hash, idx
+        );
+
+        Ok(())
+    }
+
+    fn can_advance(
+        &self,
+        protocol: &ProtocolType,
+        participants: &[CommsAddress],
+        context: &ProgramContext,
+    ) -> Result<bool, BitVMXError> {
+        let protocol_id = protocol.context().id;
+
+        for (idx, participant) in participants.iter().enumerate() {
+            if context
+                .globals
+                .get_var(&protocol_id, &format!("participant_{}_{}", idx, self.name))?
+                .is_none()
+            {
+                debug!(
+                    "AsyncDispatcherStep[{}]: Waiting for data from participant {} (index {})",
+                    self.name, participant.pubkey_hash, idx
+                );
+                return Ok(false);
+            }
+        }
+
+        debug!(
+            "AsyncDispatcherStep[{}]: All {} participants have sent their data",
+            self.name,
+            participants.len()
+        );
+        Ok(true)
+    }
+
+    fn on_step_complete(
+        &self,
+        protocol: &ProtocolType,
+        participants: &[CommsAddress],
+        context: &mut ProgramContext,
+    ) -> Result<(), BitVMXError> {
+        let protocol_id = protocol.context().id;
+
+        debug!(
+            "AsyncDispatcherStep[{}]: Collecting all participant data",
+            self.name
+        );
+
+        // Collect all participant data as JSON values
+        let mut all_data: Vec<serde_json::Value> = Vec::new();
+        for (idx, _) in participants.iter().enumerate() {
+            let data_json = context
+                .globals
+                .get_var(&protocol_id, &format!("participant_{}_{}", idx, self.name))?
+                .ok_or_else(|| {
+                    BitVMXError::InvalidMessage(format!(
+                        "Missing data for participant {} in step '{}'",
+                        idx, self.name
+                    ))
+                })?
+                .string()?;
+
+            let value: serde_json::Value = serde_json::from_str(&data_json)?;
+            all_data.push(value);
+        }
+
+        // Store the complete collection
+        context.globals.set_var(
+            &protocol_id,
+            &format!("all_{}", self.name),
+            VariableTypes::String(serde_json::to_string(&all_data)?),
+        )?;
+
+        info!(
+            "AsyncDispatcherStep[{}]: Completed with {} participants' data",
+            self.name,
+            all_data.len()
+        );
+
+        Ok(())
+    }
+}

--- a/src/program/setup/steps/garbled_handler.rs
+++ b/src/program/setup/steps/garbled_handler.rs
@@ -1,0 +1,118 @@
+use crate::{
+    config::ComponentsConfig,
+    errors::BitVMXError,
+    program::protocols::protocol_handler::ProtocolType,
+};
+use bitvmx_broker::identification::identifier::Identifier;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use super::async_dispatcher_step::AsyncStepHandler;
+
+/// Data produced by the garbled circuit handler.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GarbledStepData {
+    pub digest_circ: String,
+    pub digest_ct: String,
+    pub digest_io: String,
+    pub proof_path: Option<String>,
+}
+
+// TODO: Replace with DispatcherJob<GarbledJobType> when the garbled-dispatcher branch is merged.
+#[derive(Debug, Serialize, Deserialize)]
+struct GarbledJob {
+    job_id: String,
+    job_type: GarbledJobType,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum GarbledJobType {
+    /// Prove(input_bytes, circuit_type, output_dir)
+    Prove(Vec<u8>, String, String),
+}
+
+/// [`AsyncStepHandler`] for garbled circuits.
+///
+/// TODO: Current implementation uses mock data. Replace internals with real
+/// `DispatcherJob<GarbledJobType>` when the garbled-dispatcher branch is merged.
+#[derive(Debug, Clone)]
+pub struct GarbledHandler;
+
+impl AsyncStepHandler for GarbledHandler {
+    fn create_job(
+        &self,
+        protocol_id: &Uuid,
+        _protocol: &mut ProtocolType,
+    ) -> Result<String, BitVMXError> {
+        let job_id = protocol_id.to_string();
+        let output_dir = format!("./garbled-jobs/{}", job_id);
+
+        // TODO: Get real input and circuit type from protocol
+        let job = GarbledJob {
+            job_id,
+            job_type: GarbledJobType::Prove(
+                vec![1, 1, 0],
+                "simple".to_string(),
+                output_dir,
+            ),
+        };
+
+        serde_json::to_string(&job).map_err(|e| {
+            BitVMXError::InvalidMessage(format!("Failed to serialize garbled job: {}", e))
+        })
+    }
+
+    fn parse_result(&self, result: &[u8]) -> Result<String, BitVMXError> {
+        let result_json: serde_json::Value =
+            serde_json::from_slice(result).map_err(|e| {
+                BitVMXError::InvalidMessage(format!(
+                    "Failed to parse garbled result: {}",
+                    e
+                ))
+            })?;
+
+        let step_data = GarbledStepData {
+            digest_circ: result_json["digest_circ"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            digest_ct: result_json["digest_ct"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            digest_io: result_json["digest_io"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string(),
+            proof_path: result_json["proof_path"].as_str().map(|s| s.to_string()),
+        };
+
+        serde_json::to_string(&step_data).map_err(|e| {
+            BitVMXError::InvalidMessage(format!("Failed to serialize garbled step data: {}", e))
+        })
+    }
+
+    fn validate_received(&self, data: &str) -> Result<(), BitVMXError> {
+        let step_data: GarbledStepData = serde_json::from_str(data).map_err(|e| {
+            BitVMXError::InvalidMessage(format!(
+                "Failed to deserialize garbled step data: {}",
+                e
+            ))
+        })?;
+
+        if step_data.digest_circ.is_empty()
+            || step_data.digest_ct.is_empty()
+            || step_data.digest_io.is_empty()
+        {
+            return Err(BitVMXError::InvalidMessage(
+                "Received garbled step data with empty digests".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn dispatcher_id(&self, config: &ComponentsConfig) -> Option<Identifier> {
+        config.garbled.clone()
+    }
+}

--- a/src/program/setup/steps/mod.rs
+++ b/src/program/setup/steps/mod.rs
@@ -1,20 +1,27 @@
+pub mod async_dispatcher_step;
 pub mod keys_step;
+pub mod garbled_handler;
 pub mod nonces_step;
 pub mod signatures_step;
 
+pub use async_dispatcher_step::{AsyncDispatcherStep, AsyncStepHandler};
 pub use keys_step::KeysStep;
+pub use garbled_handler::GarbledHandler;
 pub use nonces_step::NoncesStep;
 pub use signatures_step::SignaturesStep;
 
 use enum_dispatch::enum_dispatch;
 
 use super::SetupStep;
+use crate::config::ComponentsConfig;
 use crate::errors::BitVMXError;
 use crate::program::participant::CommsAddress;
 use crate::program::protocols::protocol_handler::ProtocolType;
 use crate::types::ProgramContext;
+use bitvmx_broker::identification::identifier::Identifier;
 use std::fmt;
 use std::str::FromStr;
+use uuid::Uuid;
 
 /// Enum representing the available setup step types.
 ///
@@ -24,6 +31,7 @@ pub enum SetupStepName {
     Keys,
     Nonces,
     Signatures,
+    GarbledCircuits,
 }
 
 impl SetupStepName {
@@ -33,6 +41,7 @@ impl SetupStepName {
             SetupStepName::Keys => "keys",
             SetupStepName::Nonces => "nonces",
             SetupStepName::Signatures => "signatures",
+            SetupStepName::GarbledCircuits => "garbled_circuits",
         }
     }
 }
@@ -51,8 +60,9 @@ impl FromStr for SetupStepName {
             "keys" => Ok(SetupStepName::Keys),
             "nonces" => Ok(SetupStepName::Nonces),
             "signatures" => Ok(SetupStepName::Signatures),
+            "garbled_circuits" => Ok(SetupStepName::GarbledCircuits),
             _ => Err(BitVMXError::InvalidMessage(format!(
-                "Unknown setup step name: '{}'. Valid names are: 'keys', 'nonces', 'signatures'",
+                "Unknown setup step name: '{}'. Valid names are: 'keys', 'nonces', 'signatures', 'garbled_circuits'",
                 s
             ))),
         }
@@ -75,6 +85,16 @@ pub enum SetupStepEnum {
     Keys(KeysStep),
     Nonces(NoncesStep),
     Signatures(SignaturesStep),
+    AsyncDispatcher(AsyncDispatcherStep),
+}
+
+/// Concrete enum grouping all [`AsyncStepHandler`] implementations.
+///
+/// When adding a new async dispatcher type, add a variant here.
+#[enum_dispatch(AsyncStepHandler)]
+#[derive(Debug, Clone)]
+pub enum AsyncStepHandlerEnum {
+    Garbled(GarbledHandler),
 }
 
 /// Factory function to create a concrete `SetupStepEnum` from its name.
@@ -83,5 +103,8 @@ pub fn create_setup_step(name: &SetupStepName) -> SetupStepEnum {
         SetupStepName::Keys => SetupStepEnum::Keys(KeysStep::new()),
         SetupStepName::Nonces => SetupStepEnum::Nonces(NoncesStep::new()),
         SetupStepName::Signatures => SetupStepEnum::Signatures(SignaturesStep::new()),
+        SetupStepName::GarbledCircuits => {
+            SetupStepEnum::AsyncDispatcher(AsyncDispatcherStep::new("garbled_circuits"))
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,11 +20,14 @@ use redact::Secret;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use std::collections::HashMap;
+
 use crate::{
     errors::BitVMXError,
     leader_broadcast::LeaderBroadcastHelper,
     program::{
         participant::CommsAddress,
+        setup::steps::AsyncStepHandlerEnum,
         variables::{Globals, VariableTypes, WitnessTypes, WitnessVars},
     },
 };
@@ -39,6 +42,7 @@ pub struct ProgramContext {
     pub witness: WitnessVars,
     pub components_config: ComponentsConfig,
     pub leader_broadcast_helper: LeaderBroadcastHelper,
+    pub async_step_handlers: HashMap<String, AsyncStepHandlerEnum>,
 }
 
 impl ProgramContext {
@@ -63,7 +67,21 @@ impl ProgramContext {
             witness,
             components_config,
             leader_broadcast_helper,
+            async_step_handlers: HashMap::new(),
         }
+    }
+
+    /// Register an async step handler for a given step name.
+    ///
+    /// The handler will be used by `AsyncDispatcherStep` when the step with
+    /// the matching name runs during protocol setup.
+    pub fn register_async_step_handler(
+        &mut self,
+        step_name: &str,
+        handler: AsyncStepHandlerEnum,
+    ) {
+        self.async_step_handlers
+            .insert(step_name.to_string(), handler);
     }
 }
 
@@ -358,6 +376,7 @@ pub struct ParticipantChannel {
 }
 
 pub const PROGRAM_TYPE_AGGREGATED_KEY: &str = "aggregated_key";
+pub const PROGRAM_TYPE_GARBLED: &str = "garbled";
 pub const PROGRAM_TYPE_LOCK: &str = "lock";
 pub const PROGRAM_TYPE_DRP: &str = "drp";
 pub const PROGRAM_TYPE_SLOT: &str = "slot";

--- a/tests/garbled_test.rs
+++ b/tests/garbled_test.rs
@@ -1,0 +1,356 @@
+#![cfg(test)]
+
+use anyhow::Result;
+use bitvmx_broker::{
+    channel::channel::DualChannel,
+    identification::{allow_list::AllowList, identifier::Identifier},
+    rpc::{tls_helper::Cert, BrokerConfig},
+};
+use bitvmx_client::{
+    config::Config,
+    program::{setup::steps::GarbledHandler, variables::VariableTypes},
+    types::{IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, ParticipantChannel},
+};
+use bitvmx_job_dispatcher::{dispatcher_job::ResultMessage, helper::PingMessage};
+use bitvmx_settings::settings;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+mod common;
+use common::{config_trace, get_all, init_bitvmx, prepare_bitcoin_guarded, send_all, tick};
+
+/// Mirrors the MockGarbledJob struct from the client's async_dispatcher_step.rs
+#[derive(Debug, Deserialize)]
+struct MockGarbledJob {
+    job_id: String,
+    job_type: MockGarbledJobType,
+}
+
+#[derive(Debug, Deserialize)]
+enum MockGarbledJobType {
+    Prove(#[allow(dead_code)] Vec<u8>, String, String),
+}
+
+/// Mock result matching the garbled-dispatcher's ProveResult format
+#[derive(Debug, Serialize)]
+struct MockProveResult {
+    r#type: String,
+    status: String,
+    circuit_type: String,
+    num_gates: u32,
+    num_inputs: u32,
+    digest_circ: String,
+    digest_ct: String,
+    digest_io: String,
+    proof_path: String,
+}
+
+/// Creates a DualChannel that acts as the mock garbled dispatcher.
+///
+/// Reuses the prover key with a distinct ID (99) so it has a unique identity
+/// on the broker, separate from any real dispatchers.
+fn create_mock_garbled_channel(config: &Config) -> Result<(DualChannel, Identifier)> {
+    let allow_list = AllowList::from_file(&config.broker.allow_list)?;
+    let broker_config = BrokerConfig::new(config.broker.port, None, config.broker.get_pubk_hash()?);
+
+    let priv_key = settings::decrypt_or_read_file(&config.testing.prover.priv_key)?;
+    let cert = Cert::new_with_privk(&priv_key)?;
+    let pubkey_hash = cert.get_pubk_hash()?;
+
+    let garbled_id: u8 = 99; // distinct ID for the mock garbled dispatcher
+    let channel = DualChannel::new(&broker_config, cert, Some(garbled_id), allow_list)?;
+
+    let identifier = Identifier {
+        pubkey_hash,
+        id: garbled_id,
+    };
+
+    Ok((channel, identifier))
+}
+
+/// Processes one pending message from the mock garbled dispatcher channel.
+///
+/// If there's a garbled job request, creates and sends back a mock result.
+/// Returns true if a job was processed.
+fn process_mock_garbled_dispatcher(channel: &DualChannel) -> Result<bool> {
+    match channel.recv()? {
+        Some((msg, from)) => {
+            // Handle ping
+            if let Ok(PingMessage::Ping) = serde_json::from_str::<PingMessage>(&msg) {
+                let pong = serde_json::to_string(&PingMessage::Pong)?;
+                channel.send(&from, pong)?;
+                return Ok(false);
+            }
+
+            // Handle garbled job
+            let job: MockGarbledJob = serde_json::from_str(&msg)?;
+            info!(
+                "Mock garbled dispatcher: received job {} ({:?})",
+                job.job_id, job.job_type
+            );
+
+            let (circuit_type, output_dir) = match &job.job_type {
+                MockGarbledJobType::Prove(_, circuit, out) => (circuit.clone(), out.clone()),
+            };
+
+            let result = MockProveResult {
+                r#type: "ProveResult".to_string(),
+                status: "OK".to_string(),
+                circuit_type,
+                num_gates: 42,
+                num_inputs: 3,
+                digest_circ: "test_digest_circ_001".to_string(),
+                digest_ct: "test_digest_ct_002".to_string(),
+                digest_io: "test_digest_io_003".to_string(),
+                proof_path: format!("{}/proof.bin", output_dir),
+            };
+
+            let result_message = ResultMessage {
+                job_id: job.job_id,
+                result: serde_json::to_string(&result)?,
+            };
+
+            channel.send(&from, serde_json::to_string(&result_message)?)?;
+            info!("Mock garbled dispatcher: sent result");
+            Ok(true)
+        }
+        None => Ok(false),
+    }
+}
+
+/// Test the garbled protocol with async garbled circuit setup step.
+///
+/// This test exercises the complete async setup flow:
+/// 1. Keys step: participants exchange keys (synchronous)
+/// 2. GarbledCircuits step: each participant sends a job to the mock garbled dispatcher
+///    and waits for the result (asynchronous)
+/// 3. After both steps complete, the setup is finalized
+#[ignore]
+#[test]
+pub fn test_garbled_setup() -> Result<()> {
+    config_trace();
+
+    let (_bitcoin_client, _bitcoind_guard, _wallet) = prepare_bitcoin_guarded()?;
+
+    // Initialize 2 BitVMX instances
+    let config_op1 = Config::new(Some("config/op_1.yaml".to_string()))?;
+    let config_op2 = Config::new(Some("config/op_2.yaml".to_string()))?;
+    let (mut bitvmx_op1, _addr1, bridge_op1, _) = init_bitvmx("op_1", false)?;
+    let (mut bitvmx_op2, _addr2, bridge_op2, _) = init_bitvmx("op_2", false)?;
+
+    // Each operator has its own broker, so we need a mock garbled channel per broker
+    let (mock_garbled_channel_op1, garbled_identifier) =
+        create_mock_garbled_channel(&config_op1)?;
+    let (mock_garbled_channel_op2, _) = create_mock_garbled_channel(&config_op2)?;
+
+    // Inject the garbled dispatcher identifier and handler into both instances
+    bitvmx_op1.set_garbled_identifier(garbled_identifier.clone());
+    bitvmx_op1.register_async_step_handler("garbled_circuits", GarbledHandler.into());
+    bitvmx_op2.set_garbled_identifier(garbled_identifier.clone());
+    bitvmx_op2.register_async_step_handler("garbled_circuits", GarbledHandler.into());
+
+    let mut instances = vec![bitvmx_op1, bitvmx_op2];
+    let channels = vec![bridge_op1.clone(), bridge_op2.clone()];
+
+    let identifiers = [
+        instances[0].get_components_config().bitvmx.clone(),
+        instances[1].get_components_config().bitvmx.clone(),
+    ];
+
+    let id_channel_pairs: Vec<ParticipantChannel> = identifiers
+        .into_iter()
+        .zip(channels.clone().into_iter())
+        .map(|(id, channel)| ParticipantChannel { id, channel })
+        .collect();
+
+    info!("================================================");
+    info!("Syncing Bitcoin blockchain");
+    info!("================================================");
+
+    for _ in 0..101 {
+        for instance in instances.iter_mut() {
+            instance.process_bitcoin_updates()?;
+        }
+    }
+
+    info!("================================================");
+    info!("Getting participant addresses");
+    info!("================================================");
+
+    let command = IncomingBitVMXApiMessages::GetCommInfo(Uuid::new_v4()).to_string()?;
+    send_all(&id_channel_pairs, &command)?;
+    let comm_info: Vec<OutgoingBitVMXApiMessages> = get_all(&channels, &mut instances, false)?;
+    let addresses = comm_info
+        .iter()
+        .map(|msg| msg.comm_info().unwrap().1)
+        .collect::<Vec<_>>();
+
+    info!("Op1 (Leader) address: {:?}", addresses[0]);
+    info!("Op2 (Non-leader) address: {:?}", addresses[1]);
+
+    info!("================================================");
+    info!("Setting up garbled protocol");
+    info!("================================================");
+
+    let program_id = Uuid::new_v4();
+    let command = IncomingBitVMXApiMessages::Setup(
+        program_id,
+        "garbled".to_string(),
+        addresses.clone(),
+        0, // Op1 is leader
+    )
+    .to_string()?;
+    send_all(&id_channel_pairs, &command)?;
+
+    info!("================================================");
+    info!("Running setup loop (Keys + GarbledCircuits steps)");
+    info!("================================================");
+
+    // Drive the setup loop: tick all instances and process mock garbled dispatcher
+    // The flow is:
+    //   1. Keys step completes synchronously via tick + comms
+    //   2. GarbledCircuits step sends job → WaitingGeneration
+    //   3. Mock dispatcher receives job → sends result
+    //   4. Client receives result → WaitingForParticipants → Completed
+    let mut setup_completed_count = 0;
+    let max_iterations = 5000;
+
+    for i in 0..max_iterations {
+        // Process mock garbled dispatchers (one per broker)
+        process_mock_garbled_dispatcher(&mock_garbled_channel_op1)?;
+        process_mock_garbled_dispatcher(&mock_garbled_channel_op2)?;
+
+        // Tick all instances
+        for instance in instances.iter_mut() {
+            tick(instance)?;
+        }
+
+        // Check for SetupCompleted messages
+        for channel in &channels {
+            if let Some((msg, _from)) = channel.recv()? {
+                let decoded = OutgoingBitVMXApiMessages::from_string(&msg)?;
+                if let OutgoingBitVMXApiMessages::SetupCompleted(id) = &decoded {
+                    info!("Received SetupCompleted for program {}", id);
+                    setup_completed_count += 1;
+                }
+            }
+        }
+
+        if setup_completed_count >= 2 {
+            info!("Both participants completed setup at iteration {}", i);
+            break;
+        }
+
+        if i % 500 == 0 && i > 0 {
+            info!(
+                "Setup loop iteration {} (completed: {})",
+                i, setup_completed_count
+            );
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+
+    assert!(
+        setup_completed_count >= 2,
+        "Expected both participants to complete setup, got {}",
+        setup_completed_count
+    );
+
+    info!("================================================");
+    info!("Verifying garbled circuit data in globals");
+    info!("================================================");
+
+    // Query the garbled circuit data from all participants
+    let get_garbled_command =
+        IncomingBitVMXApiMessages::GetVar(program_id, "all_garbled_circuits".to_string())
+            .to_string()?;
+
+    send_all(&id_channel_pairs, &get_garbled_command)?;
+    let garbled_responses = get_all(&channels, &mut instances, false)?;
+
+    for (i, response) in garbled_responses.iter().enumerate() {
+        if let Some((_, key_name, key_value)) = response.variable() {
+            info!(
+                "Participant {} garbled data: {} = {:?}",
+                i, key_name, key_value
+            );
+            assert_eq!(key_name, "all_garbled_circuits");
+
+            if let VariableTypes::String(data_json) = key_value {
+                // Parse and verify the garbled data
+                let data: Vec<serde_json::Value> = serde_json::from_str(&data_json)?;
+                assert_eq!(
+                    data.len(),
+                    2,
+                    "Should have garbled data from both participants"
+                );
+
+                // Verify each participant's data has the expected mock digests
+                for participant_data in &data {
+                    assert_eq!(
+                        participant_data["digest_circ"].as_str().unwrap(),
+                        "test_digest_circ_001"
+                    );
+                    assert_eq!(
+                        participant_data["digest_ct"].as_str().unwrap(),
+                        "test_digest_ct_002"
+                    );
+                    assert_eq!(
+                        participant_data["digest_io"].as_str().unwrap(),
+                        "test_digest_io_003"
+                    );
+                }
+
+                info!(
+                    "Participant {} has valid garbled circuit data from {} participants",
+                    i,
+                    data.len()
+                );
+            } else {
+                panic!(
+                    "Expected String variable for garbled data, got {:?}",
+                    key_value
+                );
+            }
+        } else {
+            panic!("Participant {} did not return the garbled data variable", i);
+        }
+    }
+
+    // Also verify the aggregated key from the Keys step
+    let get_key_command =
+        IncomingBitVMXApiMessages::GetVar(program_id, "garbled_aggregated_key".to_string())
+            .to_string()?;
+    send_all(&id_channel_pairs, &get_key_command)?;
+    let key_responses = get_all(&channels, &mut instances, false)?;
+
+    let mut keys = Vec::new();
+    for (i, response) in key_responses.iter().enumerate() {
+        if let Some((_, _, key_value)) = response.variable() {
+            if let VariableTypes::PubKey(key) = key_value {
+                info!("Participant {} aggregated key: {}", i, key);
+                keys.push(key.to_string());
+            }
+        }
+    }
+    assert_eq!(
+        keys.len(),
+        2,
+        "Both participants should have the aggregated key"
+    );
+    assert_eq!(
+        keys[0], keys[1],
+        "Both participants should have the same aggregated key"
+    );
+
+    info!("================================================");
+    info!("Test completed successfully!");
+    info!("  - Keys step: completed (aggregated key matches)");
+    info!("  - GarbledCircuits step: completed (async flow worked)");
+    info!("  - All garbled data verified across participants");
+    info!("================================================");
+
+    Ok(())
+}


### PR DESCRIPTION
Add AsyncDispatcherStep + AsyncStepHandler trait (via enum_dispatch) to support async setup steps that delegate work to external job dispatchers. The first implementation is GarbledHandler for garbled circuit generation.

Key changes:
- AsyncDispatcherStep: generic setup step that sends jobs to dispatchers and waits for results asynchronously (Generating → WaitingGeneration → WaitingForParticipants → Completed)
- AsyncStepHandler trait: create_job, parse_result, validate_received, dispatcher_id — decoupled from any specific dispatcher
- SetupStepMessage wrapper: tags broadcast data with step name to prevent stale messages from completed steps being misrouted
- GarbledProtocol: protocol using [Keys, GarbledCircuits] setup steps
- Integration test exercising the full async flow with mock dispatcher