### PR TITLE
generalize output pattern monitoring for RSK pegin transactions

### DIFF
--- a/examples/union/participants/user.rs
+++ b/examples/union/participants/user.rs
@@ -30,7 +30,7 @@ use bitvmx_client::{
         variables::PartialUtxo,
     },
     spv_proof::BtcTxSPVProof,
-    types::OutgoingBitVMXApiMessages::*,
+    types::{OutgoingBitVMXApiMessages::*, OutputPatternFilter, RSK_PEGIN_TAG},
 };
 
 const KEY_SPEND_FEE: u64 = 135;
@@ -106,9 +106,16 @@ impl User {
     ) -> Result<(Txid, Transaction)> {
         info!(id = self.id, "Requesting pegin");
 
-        // Enable RSK pegin monitoring using the public API
+        // Enable output pattern monitoring for RSK pegin transactions
         //TOOD: Define proper confirmation threshold
-        self.bitvmx.subscribe_to_rsk_pegin(Some(1))?;
+        self.bitvmx.subscribe_to_output_pattern(
+            OutputPatternFilter {
+                output_index: 1,
+                tag: RSK_PEGIN_TAG.to_vec(),
+                max_outputs: None,
+            },
+            Some(1),
+        )?;
 
         // Create a proper RSK pegin transaction and send it as if it was a user transaction
         let packet_number = 0;
@@ -145,8 +152,8 @@ impl User {
             request_pegin_txid
         );
 
-        // Wait for Bitvmx news PeginTransactionFound message
-        let (_, _) = wait_until_msg!(&self.bitvmx, PeginTransactionFound(_txid, _tx_status) => (_txid, _tx_status));
+        // Wait for Bitvmx news OutputPatternTransactionFound message
+        let (_, _, _) = wait_until_msg!(&self.bitvmx, OutputPatternTransactionFound(_txid, _tx_status, _tag) => (_txid, _tx_status, _tag));
         info!("RSK request pegin completed");
         info!("Waiting for SPV proof...");
 

--- a/src/bitvmx.rs
+++ b/src/bitvmx.rs
@@ -19,7 +19,7 @@ use crate::{
     signature_verifier::SignatureVerifier,
     types::{
         IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, ProgramContext, ProgramStatus,
-        PROGRAM_TYPE_AGGREGATED_KEY,
+        RSK_PEGIN_TAG, PROGRAM_TYPE_AGGREGATED_KEY,
     },
 };
 use bitcoin::secp256k1::Message;
@@ -609,14 +609,25 @@ impl BitVMX {
                         context_data,
                     ));
                 }
-                MonitorNews::RskPeginTransaction(tx_id, tx_status) => {
-                    let data = serde_json::to_string(
-                        &OutgoingBitVMXApiMessages::PeginTransactionFound(tx_id, tx_status),
-                    )?;
+                MonitorNews::OutputPatternTransaction(tx_id, tx_status, tag) => {
+                    if tag == RSK_PEGIN_TAG {
+                        let legacy = OutgoingBitVMXApiMessages::PeginTransactionFound(tx_id, tx_status.clone());
+                        let data = serde_json::to_string(&legacy)?;
+                        self.program_context
+                            .broker_channel
+                            .send(&self.config.components.l2, data)?;
+                    }
+                    let outgoing = OutgoingBitVMXApiMessages::OutputPatternTransactionFound(
+                        tx_id,
+                        tx_status,
+                        tag.clone(),
+                    );
+                    let data = serde_json::to_string(&outgoing)?;
                     self.program_context
                         .broker_channel
                         .send(&self.config.components.l2, data)?;
-                    ack_news = AckNews::Monitor(AckMonitorNews::RskPeginTransaction(tx_id));
+                    ack_news =
+                        AckNews::Monitor(AckMonitorNews::OutputPatternTransaction(tx_id, tag));
                 }
                 MonitorNews::NewBlock(block_height, block_hash) => {
                     debug!("New block: {} {}", block_height, block_hash);
@@ -1232,14 +1243,14 @@ impl BitVMX {
         Ok(())
     }
 
-    fn subscribe_to_rsk_pegin(
+    fn subscribe_to_output_pattern(
         &mut self,
+        filter: bitcoin_coordinator::OutputPatternFilter,
         confirmation_threshold: Option<u32>,
     ) -> Result<(), BitVMXError> {
-        // Enable RSK pegin transaction monitoring
         self.program_context
             .bitcoin_coordinator
-            .monitor(TypesToMonitor::RskPegin(confirmation_threshold))?;
+            .monitor(TypesToMonitor::OutputPattern(filter, confirmation_threshold))?;
         Ok(())
     }
 
@@ -1496,8 +1507,18 @@ impl BitVMX {
                 txid,
                 confirmation_threshold,
             ) => self.subscribe_to_tx(from, uuid, txid, confirmation_threshold)?,
+            IncomingBitVMXApiMessages::SubscribeToOutputPattern(filter, confirmation_threshold) => {
+                self.subscribe_to_output_pattern(filter, confirmation_threshold)?
+            }
             IncomingBitVMXApiMessages::SubscribeToRskPegin(confirmation_threshold) => {
-                self.subscribe_to_rsk_pegin(confirmation_threshold)?
+                self.subscribe_to_output_pattern(
+                    bitcoin_coordinator::OutputPatternFilter {
+                        output_index: 1,
+                        tag: RSK_PEGIN_TAG.to_vec(),
+                        max_outputs: None,
+                    },
+                    confirmation_threshold,
+                )?
             }
             IncomingBitVMXApiMessages::GetSPVProof(txid) => self.get_spv_proof(from, txid)?,
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::{
         participant::CommsAddress,
         variables::{VariableTypes, WitnessTypes},
     },
-    types::{IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages},
+    types::{IncomingBitVMXApiMessages, OutgoingBitVMXApiMessages, OutputPatternFilter},
 };
 use anyhow::Result;
 use bitcoin::{PublicKey, Transaction, Txid};
@@ -154,6 +154,17 @@ impl BitVMXClient {
         self.send_message(IncomingBitVMXApiMessages::SubscribeToTransaction(
             request_id,
             txid,
+            confirmation_threshold,
+        ))
+    }
+
+    pub fn subscribe_to_output_pattern(
+        &self,
+        filter: OutputPatternFilter,
+        confirmation_threshold: Option<u32>,
+    ) -> Result<()> {
+        self.send_message(IncomingBitVMXApiMessages::SubscribeToOutputPattern(
+            filter,
             confirmation_threshold,
         ))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -28,6 +28,8 @@ use crate::{
         variables::{Globals, VariableTypes, WitnessTypes, WitnessVars},
     },
 };
+pub use bitcoin_coordinator::OutputPatternFilter;
+pub const RSK_PEGIN_TAG: &[u8] = b"RSK_PEGIN";
 
 pub struct ProgramContext {
     pub key_manager: Rc<KeyManager>,
@@ -93,6 +95,7 @@ pub enum IncomingBitVMXApiMessages {
     GetHashedMessage(Uuid, String, u32, u32),
     Setup(ProgramId, String, Vec<CommsAddress>, u16),
     SubscribeToTransaction(Uuid, Txid, Option<u32>),
+    SubscribeToOutputPattern(OutputPatternFilter, Option<u32>),
     SubscribeToRskPegin(Option<u32>),
     GetSPVProof(Txid),
     DispatchTransaction(Uuid, Transaction, Option<u32>),
@@ -131,7 +134,9 @@ pub enum OutgoingBitVMXApiMessages {
     Pong(Uuid),
     // response for transaction get and dispatch
     Transaction(Uuid, TransactionStatus, Option<String>),
-    // Represents when pegin transactions is found
+    // Represents when a transaction matching a generic output pattern is found
+    OutputPatternTransactionFound(Txid, TransactionStatus, Vec<u8>),
+    // Represents when a RSK pegin transaction is found (kept for backward compatibility)
     PeginTransactionFound(Txid, TransactionStatus),
     // Represents when a spending utxo transaction is found
     SpendingUTXOTransactionFound(Uuid, Txid, u32, TransactionStatus),
@@ -285,6 +290,9 @@ impl OutgoingBitVMXApiMessages {
         match self {
             OutgoingBitVMXApiMessages::Pong(_) => "Pong".to_string(),
             OutgoingBitVMXApiMessages::Transaction(_, _, _) => "Transaction".to_string(),
+            OutgoingBitVMXApiMessages::OutputPatternTransactionFound(_, _, _) => {
+                "OutputPatternTransactionFound".to_string()
+            }
             OutgoingBitVMXApiMessages::PeginTransactionFound(_, _) => {
                 "PeginTransactionFound".to_string()
             }


### PR DESCRIPTION
override: rust-bitvmx-transaction-monitor: generalize-output-pattern-monitor
override: rust-bitcoin-coordinator: generalize-output-pattern-monitor